### PR TITLE
Centralising validation

### DIFF
--- a/QuEST/CPU/QuEST_cpu.c
+++ b/QuEST/CPU/QuEST_cpu.c
@@ -1621,7 +1621,7 @@ void statevec_hadamardDistributed(QubitRegister qureg, const int targetQubit,
 
 void statevec_phaseShiftByTerm (QubitRegister qureg, const int targetQubit, Complex term)
 {
-	QuESTAssert(validateUnitComplex(term), 16, __func__);
+	QuESTAssert(isComplexUnit(term), 16, __func__);
 	
     long long int index;
     long long int stateVecSize;

--- a/QuEST/CPU/QuEST_cpu.c
+++ b/QuEST/CPU/QuEST_cpu.c
@@ -13,6 +13,9 @@
 
 # include "QuEST_cpu_internal.h"
 
+// debug: remove this after all validation is removed
+# include "../QuEST_validation.h"
+
 # include <math.h>  
 # include <stdio.h>
 # include <stdlib.h>

--- a/QuEST/CPU/QuEST_cpu.c
+++ b/QuEST/CPU/QuEST_cpu.c
@@ -1983,7 +1983,7 @@ void statevec_multiControlledPhaseFlip(QubitRegister qureg, int *controlQubits, 
  *  @param[in] totalProbability probability of qubit measureQubit being either zero or one
  *  @param[in] outcome to measure the probability of and set the state to -- either zero or one
  */
-void statevec_collapseToOutcomeLocal(QubitRegister qureg, int measureQubit, REAL totalProbability, int outcome)
+void statevec_collapseToKnownProbOutcomeLocal(QubitRegister qureg, int measureQubit, int outcome, REAL totalProbability)
 {
     // ----- sizes
     long long int sizeBlock,                                  // size of blocks
@@ -2065,7 +2065,7 @@ void statevec_collapseToOutcomeLocal(QubitRegister qureg, int measureQubit, REAL
  *  @param[in] measureQubit qubit to measure
  *  @param[in] totalProbability probability of qubit measureQubit being zero
  */
-REAL statevec_collapseToOutcomeDistributedRenorm (QubitRegister qureg, const int measureQubit, const REAL totalProbability)
+void statevec_collapseToKnownProbOutcomeDistributedRenorm (QubitRegister qureg, const int measureQubit, const REAL totalProbability)
 {
     // ----- temp variables
     long long int thisTask;                                   
@@ -2090,7 +2090,6 @@ REAL statevec_collapseToOutcomeDistributedRenorm (QubitRegister qureg, const int
             stateVecImag[thisTask] = stateVecImag[thisTask]*renorm;
         }
     }
-    return totalProbability;
 }
 
 /** Set all amplitudes in one chunk to 0. 
@@ -2105,7 +2104,7 @@ REAL statevec_collapseToOutcomeDistributedRenorm (QubitRegister qureg, const int
  *  @param[in,out] qureg object representing the set of qubits
  *  @param[in] measureQubit qubit to measure
  */
-void statevec_collapseToOutcomeDistributedSetZero(QubitRegister qureg, const int measureQubit)
+void statevec_collapseToOutcomeDistributedSetZero(QubitRegister qureg)
 {
     // ----- temp variables
     long long int thisTask;                                   

--- a/QuEST/CPU/QuEST_cpu.c
+++ b/QuEST/CPU/QuEST_cpu.c
@@ -45,9 +45,6 @@ void densmatr_initPureStateDistributed(QubitRegister targetQureg, QubitRegister 
 }
 
 
-
-
-
 void densmatr_initClassicalState (QubitRegister qureg, long long int stateInd)
 {
     // dimension of the state vector
@@ -1628,9 +1625,7 @@ void statevec_hadamardDistributed(QubitRegister qureg, const int targetQubit,
 }
 
 void statevec_phaseShiftByTerm (QubitRegister qureg, const int targetQubit, Complex term)
-{
-	QuESTAssert(isComplexUnit(term), 16, __func__);
-	
+{	
     long long int index;
     long long int stateVecSize;
     int targetBit;
@@ -1716,11 +1711,9 @@ void statevec_multiControlledPhaseShift(QubitRegister qureg, int *controlQubits,
     const long long int chunkSize=qureg.numAmpsPerChunk;
     const long long int chunkId=qureg.chunkId;
 
-    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
     long long int mask=0;
     for (int i=0; i<numControlQubits; i++) 
 		mask = mask | (1LL<<controlQubits[i]);
-    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubitsInStateVec)-1, 2, __func__);
 
     stateVecSize = qureg.numAmpsPerChunk;
     REAL *stateVecReal = qureg.stateVec.real;
@@ -1912,11 +1905,7 @@ void statevec_controlledPhaseFlip (QubitRegister qureg, const int idQubit1, cons
 
     const long long int chunkSize=qureg.numAmpsPerChunk;
     const long long int chunkId=qureg.chunkId;
-
-    QuESTAssert(idQubit1 >= 0 && idQubit1 < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(idQubit2 >= 0 && idQubit2 < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(idQubit1 != idQubit2, 3, __func__);
-
+	
     // dimension of the state vector
     stateVecSize = qureg.numAmpsPerChunk;
     REAL *stateVecReal = qureg.stateVec.real;
@@ -1947,10 +1936,9 @@ void statevec_multiControlledPhaseFlip(QubitRegister qureg, int *controlQubits, 
     const long long int chunkSize=qureg.numAmpsPerChunk;
     const long long int chunkId=qureg.chunkId;
 
-    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
     long long int mask=0;
-    for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);
-    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubitsInStateVec)-1, 2, __func__);
+    for (int i=0; i<numControlQubits; i++)
+		mask = mask | (1LL<<controlQubits[i]);
 
     stateVecSize = qureg.numAmpsPerChunk;
     REAL *stateVecReal = qureg.stateVec.real;

--- a/QuEST/CPU/QuEST_cpu.c
+++ b/QuEST/CPU/QuEST_cpu.c
@@ -63,7 +63,7 @@ void densmatr_initClassicalState (QubitRegister qureg, long long int stateInd)
     }
 	
 	// index of the single density matrix elem to set non-zero
-	long long int densityDim = 1LL << qureg.numDensityQubits;
+	long long int densityDim = 1LL << qureg.numQubitsRepresented;
 	long long int densityInd = (densityDim + 1)*stateInd;
 
 	// give the specified classical state prob 1
@@ -1746,7 +1746,7 @@ REAL densmatr_findProbabilityOfZeroLocal(QubitRegister qureg, const int measureQ
 	
 	// computes first local index containing a diagonal element
 	long long int localNumAmps = qureg.numAmpsPerChunk;
-	long long int densityDim = (1LL << qureg.numDensityQubits);
+	long long int densityDim = (1LL << qureg.numQubitsRepresented);
 	long long int diagSpacing = 1LL + densityDim;
 	long long int maxNumDiagsPerChunk = localNumAmps / diagSpacing;
 	long long int numPrevDiags = (qureg.chunkId * localNumAmps) / diagSpacing;

--- a/QuEST/CPU/QuEST_cpu.c
+++ b/QuEST/CPU/QuEST_cpu.c
@@ -13,9 +13,6 @@
 
 # include "QuEST_cpu_internal.h"
 
-// debug: remove this after all validation is removed
-# include "../QuEST_validation.h"
-
 # include <math.h>  
 # include <stdio.h>
 # include <stdlib.h>
@@ -36,6 +33,19 @@ static int extractBit (const int locationOfBitFromRight, const long long int the
 {
     return (theEncodedNumber & ( 1LL << locationOfBitFromRight )) >> locationOfBitFromRight;
 }
+
+
+
+// @TODO
+void densmatr_initPureStateDistributed(QubitRegister targetQureg, QubitRegister copyQureg) {
+
+
+	printf("densmatr_initPureStateDistributed NOT YET IMPLEMENTED ON CPU");
+
+}
+
+
+
 
 
 void densmatr_initClassicalState (QubitRegister qureg, long long int stateInd)
@@ -156,18 +166,8 @@ void densmatr_initPureStateLocal(QubitRegister targetQureg, QubitRegister copyQu
     }
 }
 
-
-
-
-// @TODO
-void densmatr_initPureStateDistributed(QubitRegister targetQureg, QubitRegister copyQureg) {
-	QuESTAssert(0, 0, __func__);
-}
-
-
 void statevec_createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv env)
 {
-    QuESTAssert(numQubits>0, 9, __func__);
     long long int numAmps = 1L << numQubits;
     long long int numAmpsPerRank = numAmps/env.numRanks;
 
@@ -461,7 +461,8 @@ void statevec_initStateDebug (QubitRegister qureg)
     }
 }
 
-void statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], QuESTEnv env){
+// returns 1 if successful, else 0
+int statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], QuESTEnv env){
     long long int chunkSize, stateVecSize;
     long long int indexInChunk, totalIndex;
 
@@ -477,7 +478,11 @@ void statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], 
     for (int rank=0; rank<(qureg->numChunks); rank++){
         if (rank==qureg->chunkId){
             fp = fopen(filename, "r");
-            QuESTAssert(fp!=NULL, 11, __func__);
+			
+			// indicate file open failure
+			if (fp == NULL)
+				return 0;
+			
             indexInChunk = 0; totalIndex = 0;
             while (fgets(line, sizeof(char)*200, fp) != NULL && totalIndex<stateVecSize){
                 if (line[0]!='#'){
@@ -502,6 +507,9 @@ void statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], 
         }
         syncQuESTEnv(env);
     }
+	
+	// indicate success
+	return 1;
 }
 
 int statevec_compareStates(QubitRegister mq1, QubitRegister mq2, REAL precision){

--- a/QuEST/CPU/QuEST_cpu.c
+++ b/QuEST/CPU/QuEST_cpu.c
@@ -188,6 +188,7 @@ void statevec_createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv 
     }
 
     qureg->numQubits = numQubits;
+	qureg->numAmpsTotal = numAmps;
     qureg->numAmpsPerChunk = numAmpsPerRank;
     qureg->chunkId = env.rank;
     qureg->numChunks = env.numRanks;

--- a/QuEST/CPU/QuEST_cpu.c
+++ b/QuEST/CPU/QuEST_cpu.c
@@ -187,7 +187,7 @@ void statevec_createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv 
         exit (EXIT_FAILURE);
     }
 
-    qureg->numQubits = numQubits;
+    qureg->numQubitsInStateVec = numQubits;
 	qureg->numAmpsTotal = numAmps;
     qureg->numAmpsPerChunk = numAmpsPerRank;
     qureg->chunkId = env.rank;
@@ -207,7 +207,7 @@ void statevec_destroyQubitRegister(QubitRegister qureg, QuESTEnv env){
 void statevec_reportStateToScreen(QubitRegister qureg, QuESTEnv env, int reportRank){
     long long int index;
     int rank;
-    if (qureg.numQubits<=5){
+    if (qureg.numQubitsInStateVec<=5){
         for (rank=0; rank<qureg.numChunks; rank++){
             if (qureg.chunkId==rank){
                 if (reportRank) {
@@ -233,7 +233,7 @@ void statevec_getEnvironmentString(QuESTEnv env, QubitRegister qureg, char str[2
 # ifdef _OPENMP
     numThreads=omp_get_max_threads(); 
 # endif
-    sprintf(str, "%dqubits_CPU_%dranksx%dthreads", qureg.numQubits, env.numRanks, numThreads);
+    sprintf(str, "%dqubits_CPU_%dranksx%dthreads", qureg.numQubitsInStateVec, env.numRanks, numThreads);
 }
 
 void statevec_initStateZero (QubitRegister qureg)
@@ -1705,11 +1705,11 @@ void statevec_multiControlledPhaseShift(QubitRegister qureg, int *controlQubits,
     const long long int chunkSize=qureg.numAmpsPerChunk;
     const long long int chunkId=qureg.chunkId;
 
-    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubits, 4, __func__);
+    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
     long long int mask=0;
     for (int i=0; i<numControlQubits; i++) 
 		mask = mask | (1LL<<controlQubits[i]);
-    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubits)-1, 2, __func__);
+    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubitsInStateVec)-1, 2, __func__);
 
     stateVecSize = qureg.numAmpsPerChunk;
     REAL *stateVecReal = qureg.stateVec.real;
@@ -1902,8 +1902,8 @@ void statevec_controlledPhaseFlip (QubitRegister qureg, const int idQubit1, cons
     const long long int chunkSize=qureg.numAmpsPerChunk;
     const long long int chunkId=qureg.chunkId;
 
-    QuESTAssert(idQubit1 >= 0 && idQubit1 < qureg.numQubits, 2, __func__);
-    QuESTAssert(idQubit2 >= 0 && idQubit2 < qureg.numQubits, 1, __func__);
+    QuESTAssert(idQubit1 >= 0 && idQubit1 < qureg.numQubitsInStateVec, 2, __func__);
+    QuESTAssert(idQubit2 >= 0 && idQubit2 < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(idQubit1 != idQubit2, 3, __func__);
 
     // dimension of the state vector
@@ -1936,10 +1936,10 @@ void statevec_multiControlledPhaseFlip(QubitRegister qureg, int *controlQubits, 
     const long long int chunkSize=qureg.numAmpsPerChunk;
     const long long int chunkId=qureg.chunkId;
 
-    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubits, 4, __func__);
+    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
     long long int mask=0;
     for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);
-    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubits)-1, 2, __func__);
+    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubitsInStateVec)-1, 2, __func__);
 
     stateVecSize = qureg.numAmpsPerChunk;
     REAL *stateVecReal = qureg.stateVec.real;

--- a/QuEST/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/CPU/QuEST_cpu_distributed.c
@@ -29,10 +29,26 @@
 # endif
 
 
+
+
+
 // @TODO
 void densmatr_initPureState(QubitRegister targetQureg, QubitRegister copyQureg) {
-	densmatr_initPureStateDistributed(targetQureg, copyQureg);
+
+	printf("densmatr_initPureState NOT YET IMPLEMENTED IN distributed CPU!\n");
 }
+
+// @TODO
+void densmatr_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL totalStateProb) {
+	
+	printf("densmatr_collapseToKnownProbOutcome NOT YET IMPLEMENTED IN distributed CPU!\n");
+	
+}
+
+
+
+
+
 
 REAL densmatr_calcTotalProbability(QubitRegister qureg) {
 	
@@ -320,9 +336,6 @@ void exchangeStateVectors(QubitRegister qureg, int pairRank){
 
 void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
-
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
     Complex rot1, rot2;
@@ -360,9 +373,6 @@ void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex
 
 void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(isMatrixUnitary(u), 5, __func__);
-
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
     Complex rot1, rot2;
@@ -402,11 +412,6 @@ void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2
 
 void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, Complex alpha, Complex beta)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
-
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
     Complex rot1, rot2;
@@ -446,11 +451,6 @@ void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQub
 void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, 
         ComplexMatrix2 u)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(isMatrixUnitary(u), 5, __func__);
-
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
     Complex rot1, rot2;
@@ -489,14 +489,8 @@ void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, con
 
 void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, ComplexMatrix2 u)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
-    QuESTAssert(isMatrixUnitary(u), 5, __func__);
-
     long long int mask=0;
     for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);
-    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubitsInStateVec)-1, 2, __func__);
-    QuESTAssert((mask & (1LL<<targetQubit)) != (1LL<<targetQubit), 3, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
@@ -535,8 +529,6 @@ void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, co
 }
 void statevec_sigmaX(QubitRegister qureg, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
 
@@ -564,10 +556,6 @@ void statevec_sigmaX(QubitRegister qureg, const int targetQubit)
 
 void statevec_controlledNot(QubitRegister qureg, const int controlQubit, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(controlQubit != targetQubit, 3, __func__);
-
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
     int rankIsUpper; 	// rank's chunk is in upper half of block 
@@ -596,9 +584,7 @@ void statevec_controlledNot(QubitRegister qureg, const int controlQubit, const i
 }
 
 void statevec_sigmaY(QubitRegister qureg, const int targetQubit)
-{
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-	
+{	
 	int conjFac = 1;
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
@@ -623,9 +609,7 @@ void statevec_sigmaY(QubitRegister qureg, const int targetQubit)
 }
 
 void statevec_sigmaYConj(QubitRegister qureg, const int targetQubit)
-{
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-	
+{	
 	int conjFac = -1;
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
@@ -651,10 +635,6 @@ void statevec_sigmaYConj(QubitRegister qureg, const int targetQubit)
 
 void statevec_controlledSigmaY(QubitRegister qureg, const int controlQubit, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(controlQubit != targetQubit, 3, __func__);
-	
 	int conjFac = 1;
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
@@ -688,10 +668,6 @@ void statevec_controlledSigmaY(QubitRegister qureg, const int controlQubit, cons
 
 void statevec_controlledSigmaYConj(QubitRegister qureg, const int controlQubit, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(controlQubit != targetQubit, 3, __func__);
-	
 	int conjFac = -1;
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
@@ -725,8 +701,6 @@ void statevec_controlledSigmaYConj(QubitRegister qureg, const int controlQubit, 
 
 void statevec_hadamard(QubitRegister qureg, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
 
@@ -782,8 +756,6 @@ static int isChunkToSkipInFindPZero(int chunkId, long long int chunkSize, int me
 
 REAL statevec_findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int outcome)
 {
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
-
     REAL stateProb=0, totalStateProb=0;
     int skipValuesWithinRank = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, measureQubit);
     if (skipValuesWithinRank) {
@@ -810,7 +782,7 @@ REAL densmatr_findProbabilityOfOutcome(QubitRegister qureg, const int measureQub
 	return outcomeProb;
 }
 
-REAL statevec_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL totalStateProb)
+void statevec_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL totalStateProb)
 {
     int skipValuesWithinRank = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, measureQubit);
     if (skipValuesWithinRank) {
@@ -828,5 +800,4 @@ REAL statevec_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQ
             else statevec_collapseToOutcomeDistributedSetZero(qureg);
         }
     }
-    return totalStateProb;
 }

--- a/QuEST/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/CPU/QuEST_cpu_distributed.c
@@ -36,7 +36,7 @@ REAL densmatr_calcTotalProbability(QubitRegister qureg) {
 	// computes the trace by summing every element ("diag") with global index (2^n + 1)i for i in [0, 2^n-1]
 	
 	// computes first local index containing a diagonal element
-	long long int diagSpacing = 1LL + (1LL << qureg.numDensityQubits);
+	long long int diagSpacing = 1LL + (1LL << qureg.numQubitsRepresented);
 	long long int numPrevDiags = (qureg.chunkId * qureg.numAmpsPerChunk) / diagSpacing;
 	long long int globalIndNextDiag = diagSpacing * numPrevDiags;
 	long long int localIndNextDiag = globalIndNextDiag % qureg.numAmpsPerChunk;

--- a/QuEST/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/CPU/QuEST_cpu_distributed.c
@@ -321,7 +321,7 @@ void exchangeStateVectors(QubitRegister qureg, int pairRank){
 void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta)
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
+    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
@@ -361,7 +361,7 @@ void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex
 void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u)
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
@@ -405,7 +405,7 @@ void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQub
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
+    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
@@ -449,7 +449,7 @@ void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, con
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
@@ -491,7 +491,7 @@ void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, co
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
 
     long long int mask=0;
     for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);

--- a/QuEST/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/CPU/QuEST_cpu_distributed.c
@@ -12,6 +12,9 @@
 
 # include "QuEST_cpu_internal.h"
 
+// debug: remove this after all validation is removed
+# include "../QuEST_validation.h"
+
 #define _BSD_SOURCE
 # include <unistd.h>
 # include <mpi.h>

--- a/QuEST/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/CPU/QuEST_cpu_distributed.c
@@ -317,7 +317,7 @@ void exchangeStateVectors(QubitRegister qureg, int pairRank){
 
 void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
@@ -357,7 +357,7 @@ void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex
 
 void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
@@ -399,8 +399,8 @@ void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2
 
 void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, Complex alpha, Complex beta)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
     QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
 
@@ -443,8 +443,8 @@ void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQub
 void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, 
         ComplexMatrix2 u)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
     QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
 
@@ -486,13 +486,13 @@ void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, con
 
 void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, ComplexMatrix2 u)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubits, 4, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
     QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
 
     long long int mask=0;
     for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);
-    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubits)-1, 2, __func__);
+    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubitsInStateVec)-1, 2, __func__);
     QuESTAssert((mask & (1LL<<targetQubit)) != (1LL<<targetQubit), 3, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
@@ -532,7 +532,7 @@ void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, co
 }
 void statevec_sigmaX(QubitRegister qureg, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
@@ -561,8 +561,8 @@ void statevec_sigmaX(QubitRegister qureg, const int targetQubit)
 
 void statevec_controlledNot(QubitRegister qureg, const int controlQubit, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
@@ -594,7 +594,7 @@ void statevec_controlledNot(QubitRegister qureg, const int controlQubit, const i
 
 void statevec_sigmaY(QubitRegister qureg, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
 	
 	int conjFac = 1;
 
@@ -621,7 +621,7 @@ void statevec_sigmaY(QubitRegister qureg, const int targetQubit)
 
 void statevec_sigmaYConj(QubitRegister qureg, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
 	
 	int conjFac = -1;
 
@@ -648,8 +648,8 @@ void statevec_sigmaYConj(QubitRegister qureg, const int targetQubit)
 
 void statevec_controlledSigmaY(QubitRegister qureg, const int controlQubit, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
 	
 	int conjFac = 1;
@@ -685,8 +685,8 @@ void statevec_controlledSigmaY(QubitRegister qureg, const int controlQubit, cons
 
 void statevec_controlledSigmaYConj(QubitRegister qureg, const int controlQubit, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
 	
 	int conjFac = -1;
@@ -722,7 +722,7 @@ void statevec_controlledSigmaYConj(QubitRegister qureg, const int controlQubit, 
 
 void statevec_hadamard(QubitRegister qureg, const int targetQubit)
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
 
     // flag to require memory exchange. 1: an entire block fits on one rank, 0: at most half a block fits on one rank
     int useLocalDataOnly = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, targetQubit);
@@ -779,7 +779,7 @@ static int isChunkToSkipInFindPZero(int chunkId, long long int chunkSize, int me
 
 REAL statevec_findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int outcome)
 {
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
 
     REAL stateProb=0, totalStateProb=0;
     int skipValuesWithinRank = halfMatrixBlockFitsInChunk(qureg.numAmpsPerChunk, measureQubit);
@@ -809,7 +809,7 @@ REAL densmatr_findProbabilityOfOutcome(QubitRegister qureg, const int measureQub
 
 REAL statevec_collapseToOutcome(QubitRegister qureg, const int measureQubit, int outcome)
 {
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert((outcome==0 || outcome==1), 10, __func__);
 
     REAL totalStateProb = statevec_findProbabilityOfOutcome(qureg, measureQubit, outcome);
@@ -835,7 +835,7 @@ REAL statevec_collapseToOutcome(QubitRegister qureg, const int measureQubit, int
 }
 
 int statevec_measureWithStats(QubitRegister qureg, int measureQubit, REAL *stateProb){
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
 
     int outcome;
     // find probability of qubit being in state 1
@@ -875,7 +875,7 @@ int statevec_measureWithStats(QubitRegister qureg, int measureQubit, REAL *state
 }
 
 int statevec_measure(QubitRegister qureg, int measureQubit){
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
     REAL stateProb; 
     return statevec_measureWithStats(qureg, measureQubit, &stateProb); 
 }

--- a/QuEST/CPU/QuEST_cpu_distributed.c
+++ b/QuEST/CPU/QuEST_cpu_distributed.c
@@ -12,9 +12,6 @@
 
 # include "QuEST_cpu_internal.h"
 
-// debug: remove this after all validation is removed
-# include "../QuEST_validation.h"
-
 #define _BSD_SOURCE
 # include <unistd.h>
 # include <mpi.h>

--- a/QuEST/CPU/QuEST_cpu_internal.h
+++ b/QuEST/CPU/QuEST_cpu_internal.h
@@ -98,11 +98,11 @@ REAL statevec_findProbabilityOfZeroLocal (QubitRegister qureg, const int measure
 
 REAL statevec_findProbabilityOfZeroDistributed (QubitRegister qureg, const int measureQubit);
 
-void statevec_collapseToOutcomeLocal(QubitRegister qureg, int measureQubit, REAL totalProbability, int outcome);
+void statevec_collapseToKnownProbOutcomeLocal(QubitRegister qureg, int measureQubit, int outcome, REAL totalProbability);
 
-REAL statevec_collapseToOutcomeDistributedRenorm (QubitRegister qureg, const int measureQubit, const REAL totalProbability);
+void statevec_collapseToKnownProbOutcomeDistributedRenorm (QubitRegister qureg, const int measureQubit, const REAL totalProbability);
 
-void statevec_collapseToOutcomeDistributedSetZero(QubitRegister qureg, const int measureQubit);
+void statevec_collapseToOutcomeDistributedSetZero(QubitRegister qureg);
 
 
 

--- a/QuEST/CPU/QuEST_cpu_local.c
+++ b/QuEST/CPU/QuEST_cpu_local.c
@@ -140,7 +140,7 @@ REAL statevec_getImagAmpEl(QubitRegister qureg, long long int index){
 void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta) 
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
+    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
 
     // all values required to update state vector lie in this rank
     statevec_compactUnitaryLocal(qureg, targetQubit, alpha, beta);
@@ -149,7 +149,7 @@ void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex
 void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u) 
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
 
     // all values required to update state vector lie in this rank
     statevec_unitaryLocal(qureg, targetQubit, u);
@@ -160,7 +160,7 @@ void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQub
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
+    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
 
 
     statevec_controlledCompactUnitaryLocal(qureg, controlQubit, targetQubit, alpha, beta);
@@ -171,7 +171,7 @@ void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, con
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
 
     statevec_controlledUnitaryLocal(qureg, controlQubit, targetQubit, u);
 }
@@ -180,7 +180,7 @@ void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, co
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
 
     long long int mask=0; 
     for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);

--- a/QuEST/CPU/QuEST_cpu_local.c
+++ b/QuEST/CPU/QuEST_cpu_local.c
@@ -30,7 +30,7 @@ void densmatr_initPureState(QubitRegister targetQureg, QubitRegister copyQureg) 
 	
 	QuESTAssert(targetQureg.isDensityMatrix, 14, __func__);
 	QuESTAssert( !copyQureg.isDensityMatrix, 12, __func__);
-	QuESTAssert(targetQureg.numDensityQubits==copyQureg.numQubits, 13, __func__);
+	QuESTAssert(targetQureg.numDensityQubits==copyQureg.numQubitsInStateVec, 13, __func__);
 	
 	densmatr_initPureStateLocal(targetQureg, copyQureg);
 }
@@ -136,7 +136,7 @@ REAL statevec_getImagAmpEl(QubitRegister qureg, long long int index){
 
 void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
 
     // all values required to update state vector lie in this rank
@@ -145,7 +145,7 @@ void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex
 
 void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
 
     // all values required to update state vector lie in this rank
@@ -154,8 +154,8 @@ void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2
 
 void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, Complex alpha, Complex beta) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
     QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
 
@@ -165,8 +165,8 @@ void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQub
 
 void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, ComplexMatrix2 u) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
     QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
 
@@ -175,13 +175,13 @@ void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, con
 
 void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, ComplexMatrix2 u) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubits, 4, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
     QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
 
     long long int mask=0; 
     for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);
-    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubits)-1, 2, __func__);
+    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubitsInStateVec)-1, 2, __func__);
     QuESTAssert((mask & (1LL<<targetQubit)) != (1LL<<targetQubit), 3, __func__);
 
     statevec_multiControlledUnitaryLocal(qureg, targetQubit, mask, u);
@@ -189,20 +189,20 @@ void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, co
 
 void statevec_sigmaX(QubitRegister qureg, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     statevec_sigmaXLocal(qureg, targetQubit);
 }
 
 void statevec_sigmaY(QubitRegister qureg, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
 	int conjFac = 1;
     statevec_sigmaYLocal(qureg, targetQubit, conjFac);
 }
 
 void statevec_sigmaYConj(QubitRegister qureg, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
 	int conjFac = -1;
     statevec_sigmaYLocal(qureg, targetQubit, conjFac);
 }
@@ -221,21 +221,21 @@ void statevec_controlledSigmaYConj(QubitRegister qureg, const int controlQubit, 
 
 void statevec_hadamard(QubitRegister qureg, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     statevec_hadamardLocal(qureg, targetQubit);
 }
 
 void statevec_controlledNot(QubitRegister qureg, const int controlQubit, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubits, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
+    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
     statevec_controlledNotLocal(qureg, controlQubit, targetQubit);
 }
 
 REAL statevec_findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int outcome)
 {
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
     REAL stateProb=0;
     stateProb = statevec_findProbabilityOfZeroLocal(qureg, measureQubit);
     if (outcome==1) stateProb = 1.0 - stateProb;
@@ -252,7 +252,7 @@ REAL densmatr_findProbabilityOfOutcome(QubitRegister qureg, const int measureQub
 
 REAL statevec_collapseToOutcome(QubitRegister qureg, const int measureQubit, int outcome)
 {
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert((outcome==0 || outcome==1), 10, __func__);
     REAL stateProb;
     stateProb = statevec_findProbabilityOfOutcome(qureg, measureQubit, outcome);
@@ -262,7 +262,7 @@ REAL statevec_collapseToOutcome(QubitRegister qureg, const int measureQubit, int
 }
 
 int statevec_measureWithStats(QubitRegister qureg, int measureQubit, REAL *stateProb){
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
 
     int outcome;
     // find probability of qubit being in state 1
@@ -285,7 +285,7 @@ int statevec_measureWithStats(QubitRegister qureg, int measureQubit, REAL *state
 }
 
 int statevec_measure(QubitRegister qureg, int measureQubit){
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubits, 2, __func__);
+    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
     REAL stateProb;
     return statevec_measureWithStats(qureg, measureQubit, &stateProb);
 }

--- a/QuEST/CPU/QuEST_cpu_local.c
+++ b/QuEST/CPU/QuEST_cpu_local.c
@@ -28,13 +28,20 @@
 
 
 
+
+
+
 // @TODO
+void densmatr_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL stateProb)
+{
+    //statevec_collapseToKnownProbOutcomeLocal(qureg, measureQubit, outcome, stateProb);
+}
+
+
+
+
+
 void densmatr_initPureState(QubitRegister targetQureg, QubitRegister copyQureg) {
-	
-	QuESTAssert(targetQureg.isDensityMatrix, 14, __func__);
-	QuESTAssert( !copyQureg.isDensityMatrix, 12, __func__);
-	QuESTAssert(targetQureg.numQubitsRepresented==copyQureg.numQubitsInStateVec, 13, __func__);
-	
 	densmatr_initPureStateLocal(targetQureg, copyQureg);
 }
 
@@ -139,73 +146,46 @@ REAL statevec_getImagAmpEl(QubitRegister qureg, long long int index){
 
 void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
-
-    // all values required to update state vector lie in this rank
     statevec_compactUnitaryLocal(qureg, targetQubit, alpha, beta);
 }
 
 void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(isMatrixUnitary(u), 5, __func__);
-
-    // all values required to update state vector lie in this rank
     statevec_unitaryLocal(qureg, targetQubit, u);
 }
 
 void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, Complex alpha, Complex beta) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
-
-
     statevec_controlledCompactUnitaryLocal(qureg, controlQubit, targetQubit, alpha, beta);
 }
 
 void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, ComplexMatrix2 u) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(isMatrixUnitary(u), 5, __func__);
-
     statevec_controlledUnitaryLocal(qureg, controlQubit, targetQubit, u);
 }
 
 void statevec_multiControlledUnitary(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, ComplexMatrix2 u) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
-    QuESTAssert(isMatrixUnitary(u), 5, __func__);
-
     long long int mask=0; 
-    for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);
-    QuESTAssert(mask >=0 && mask <= (1LL<<qureg.numQubitsInStateVec)-1, 2, __func__);
-    QuESTAssert((mask & (1LL<<targetQubit)) != (1LL<<targetQubit), 3, __func__);
+    for (int i=0; i<numControlQubits; i++)
+		mask = mask | (1LL<<controlQubits[i]);
 
     statevec_multiControlledUnitaryLocal(qureg, targetQubit, mask, u);
 }
 
 void statevec_sigmaX(QubitRegister qureg, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     statevec_sigmaXLocal(qureg, targetQubit);
 }
 
 void statevec_sigmaY(QubitRegister qureg, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
 	int conjFac = 1;
     statevec_sigmaYLocal(qureg, targetQubit, conjFac);
 }
 
 void statevec_sigmaYConj(QubitRegister qureg, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
 	int conjFac = -1;
     statevec_sigmaYLocal(qureg, targetQubit, conjFac);
 }
@@ -224,21 +204,16 @@ void statevec_controlledSigmaYConj(QubitRegister qureg, const int controlQubit, 
 
 void statevec_hadamard(QubitRegister qureg, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     statevec_hadamardLocal(qureg, targetQubit);
 }
 
 void statevec_controlledNot(QubitRegister qureg, const int controlQubit, const int targetQubit) 
 {
-    QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert(controlQubit != targetQubit, 3, __func__);
     statevec_controlledNotLocal(qureg, controlQubit, targetQubit);
 }
 
 REAL statevec_findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int outcome)
 {
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
     REAL stateProb=0;
     stateProb = statevec_findProbabilityOfZeroLocal(qureg, measureQubit);
     if (outcome==1) stateProb = 1.0 - stateProb;
@@ -253,8 +228,7 @@ REAL densmatr_findProbabilityOfOutcome(QubitRegister qureg, const int measureQub
 	return outcomeProb;
 }
 
-REAL statevec_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL stateProb)
+void statevec_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL stateProb)
 {
-    statevec_collapseToOutcomeLocal(qureg, measureQubit, outcome, stateProb);
-    return stateProb;
+    statevec_collapseToKnownProbOutcomeLocal(qureg, measureQubit, outcome, stateProb);
 }

--- a/QuEST/CPU/QuEST_cpu_local.c
+++ b/QuEST/CPU/QuEST_cpu_local.c
@@ -12,9 +12,6 @@
 
 # include "QuEST_cpu_internal.h"
 
-// debug: remove this after all validation is removed
-# include "../QuEST_validation.h"
-
 # include <stdlib.h>
 # include <stdio.h>
 # include <math.h>

--- a/QuEST/CPU/QuEST_cpu_local.c
+++ b/QuEST/CPU/QuEST_cpu_local.c
@@ -30,7 +30,7 @@ void densmatr_initPureState(QubitRegister targetQureg, QubitRegister copyQureg) 
 	
 	QuESTAssert(targetQureg.isDensityMatrix, 14, __func__);
 	QuESTAssert( !copyQureg.isDensityMatrix, 12, __func__);
-	QuESTAssert(targetQureg.numDensityQubits==copyQureg.numQubitsInStateVec, 13, __func__);
+	QuESTAssert(targetQureg.numQubitsRepresented==copyQureg.numQubitsInStateVec, 13, __func__);
 	
 	densmatr_initPureStateLocal(targetQureg, copyQureg);
 }
@@ -42,7 +42,7 @@ REAL densmatr_calcTotalProbability(QubitRegister qureg) {
 	REAL y, t, c;
 	c = 0;
 	
-	long long int numCols = 1LL << qureg.numDensityQubits;
+	long long int numCols = 1LL << qureg.numQubitsRepresented;
 	long long diagIndex;
 	
 	for (int col=0; col< numCols; col++) {

--- a/QuEST/CPU/QuEST_cpu_local.c
+++ b/QuEST/CPU/QuEST_cpu_local.c
@@ -12,6 +12,9 @@
 
 # include "QuEST_cpu_internal.h"
 
+// debug: remove this after all validation is removed
+# include "../QuEST_validation.h"
+
 # include <stdlib.h>
 # include <stdio.h>
 # include <math.h>

--- a/QuEST/CPU/QuEST_cpu_local.c
+++ b/QuEST/CPU/QuEST_cpu_local.c
@@ -253,43 +253,8 @@ REAL densmatr_findProbabilityOfOutcome(QubitRegister qureg, const int measureQub
 	return outcomeProb;
 }
 
-REAL statevec_collapseToOutcome(QubitRegister qureg, const int measureQubit, int outcome)
+REAL statevec_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL stateProb)
 {
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
-    QuESTAssert((outcome==0 || outcome==1), 10, __func__);
-    REAL stateProb;
-    stateProb = statevec_findProbabilityOfOutcome(qureg, measureQubit, outcome);
-    QuESTAssert(absReal(stateProb)>REAL_EPS, 8, __func__);
-    statevec_collapseToOutcomeLocal(qureg, measureQubit, stateProb, outcome);
+    statevec_collapseToOutcomeLocal(qureg, measureQubit, outcome, stateProb);
     return stateProb;
 }
-
-int statevec_measureWithStats(QubitRegister qureg, int measureQubit, REAL *stateProb){
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
-
-    int outcome;
-    // find probability of qubit being in state 1
-    REAL stateProbInternal = statevec_findProbabilityOfOutcome(qureg, measureQubit, 1);
-
-    // we can't collapse to a state that has a probability too close to zero
-    if (stateProbInternal<REAL_EPS) outcome=0;
-    else if (1-stateProbInternal<REAL_EPS) outcome=1;
-    else {
-        // ok. both P(0) and P(1) are large enough to resolve
-        // generate random float on [0,1]
-        float randNum = genrand_real1();
-        if (randNum<=stateProbInternal) outcome = 1;
-        else outcome = 0;
-    } 
-    if (outcome==0) stateProbInternal = 1-stateProbInternal;
-    statevec_collapseToOutcomeLocal(qureg, measureQubit, stateProbInternal, outcome);
-    *stateProb = stateProbInternal;
-    return outcome;
-}
-
-int statevec_measure(QubitRegister qureg, int measureQubit){
-    QuESTAssert(measureQubit >= 0 && measureQubit < qureg.numQubitsInStateVec, 2, __func__);
-    REAL stateProb;
-    return statevec_measureWithStats(qureg, measureQubit, &stateProb);
-}
-

--- a/QuEST/GPU/QuEST_gpu.cu
+++ b/QuEST/GPU/QuEST_gpu.cu
@@ -9,6 +9,9 @@
 # include "../QuEST_precision.h"
 # include "../mt19937ar.h"
 
+// debug: remove this after all validation is removed
+# include "../QuEST_validation.h"
+
 # include <stdlib.h>
 # include <stdio.h>
 # include <math.h>

--- a/QuEST/GPU/QuEST_gpu.cu
+++ b/QuEST/GPU/QuEST_gpu.cu
@@ -63,7 +63,6 @@ void __global__ densmatr_initPureStateKernel(
 	}
 }
 
-// @TODO test 
 void densmatr_initPureState(QubitRegister targetQureg, QubitRegister copyQureg)
 {
     int threadsPerCUDABlock, CUDABlocks;
@@ -74,10 +73,6 @@ void densmatr_initPureState(QubitRegister targetQureg, QubitRegister copyQureg)
 		targetQureg.deviceStateVec.real, targetQureg.deviceStateVec.imag,
 		copyQureg.deviceStateVec.real,   copyQureg.deviceStateVec.imag);
 }
-
-
-
-
 
 void __global__ densmatr_initStatePlusKernel(long long int stateVecSize, REAL *stateVecReal, REAL *stateVecImag){
     long long int index;
@@ -165,6 +160,7 @@ void statevec_createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv 
 
     qureg->numQubits = numQubits;
     qureg->numAmpsPerChunk = numAmpsPerRank;
+	qureg->numAmpsTotal = numAmps;
     qureg->chunkId = env.rank;
     qureg->numChunks = env.numRanks;
 	qureg->isDensityMatrix = 0;
@@ -502,14 +498,6 @@ int statevec_compareStates(QubitRegister mq1, QubitRegister mq2, REAL precision)
     }
     return 1;
 }
-
-
-
-
-
-
-
-
 
 __global__ void statevec_compactUnitaryKernel (QubitRegister qureg, const int rotQubit, Complex alpha, Complex beta){
     // ----- sizes
@@ -951,10 +939,6 @@ void statevec_sigmaYConj(QubitRegister qureg, const int targetQubit)
     statevec_sigmaYKernel<<<CUDABlocks, threadsPerCUDABlock>>>(qureg, targetQubit, -1);
 }
 
-
-
-
-
 __global__ void statevec_controlledSigmaYKernel(QubitRegister qureg, const int controlQubit, const int targetQubit, const int conjFac)
 {
     long long int index;
@@ -1118,7 +1102,6 @@ __global__ void statevec_multiControlledPhaseShiftKernel(QubitRegister qureg, lo
 	    stateVecImag[index] = sinAngle*stateRealLo + cosAngle*stateImagLo;
     }
 }
-
 
 void statevec_multiControlledPhaseShift(QubitRegister qureg, int *controlQubits, int numControlQubits, REAL angle)
 {

--- a/QuEST/GPU/QuEST_gpu.cu
+++ b/QuEST/GPU/QuEST_gpu.cu
@@ -122,7 +122,7 @@ void densmatr_initClassicalState(QubitRegister qureg, long long int stateInd)
     CUDABlocks = ceil((REAL)(qureg.numAmpsPerChunk)/threadsPerCUDABlock);
 	
 	// index of the desired state in the flat density matrix
-	long long int densityDim = 1LL << qureg.numDensityQubits;
+	long long int densityDim = 1LL << qureg.numQubitsRepresented;
 	long long int densityInd = (densityDim + 1)*stateInd;
 	
 	// identical to pure version
@@ -1129,7 +1129,7 @@ REAL densmatr_calcTotalProbability(QubitRegister qureg) {
 	REAL y, t, c;
 	c = 0;
 	
-	long long int numCols = 1LL << qureg.numDensityQubits;
+	long long int numCols = 1LL << qureg.numQubitsRepresented;
 	long long diagIndex;
 	
 	copyStateFromGPU(qureg);
@@ -1393,7 +1393,7 @@ __global__ void densmatr_findProbabilityOfZeroKernel(
 	// use of block here refers to contiguous amplitudes where measureQubit = 0, 
 	// (then =1) and NOT the CUDA block, which is the partitioning of CUDA threads
 	
-	long long int densityDim    = 1LL << qureg.numDensityQubits;
+	long long int densityDim    = 1LL << qureg.numQubitsRepresented;
 	long long int numTasks      = densityDim >> 1;
 	long long int sizeHalfBlock = 1LL << (measureQubit);
 	long long int sizeBlock     = 2LL * sizeHalfBlock;
@@ -1492,7 +1492,7 @@ void swapDouble(REAL **a, REAL **b){
 
 REAL densmatr_findProbabilityOfZero(QubitRegister qureg, const int measureQubit)
 {
-	long long int densityDim = 1LL << qureg.numDensityQubits;
+	long long int densityDim = 1LL << qureg.numQubitsRepresented;
 	long long int numValuesToReduce = densityDim >> 1;  // half of the diagonal has measureQubit=0
 	
 	int valuesPerCUDABlock, numCUDABlocks, sharedMemSize;

--- a/QuEST/GPU/QuEST_gpu.cu
+++ b/QuEST/GPU/QuEST_gpu.cu
@@ -450,6 +450,7 @@ void statevec_initStateOfSingleQubit(QubitRegister *qureg, int qubitId, int outc
     statevec_initStateOfSingleQubitKernel<<<CUDABlocks, threadsPerCUDABlock>>>(qureg->numAmpsPerChunk, qureg->deviceStateVec.real, qureg->deviceStateVec.imag, qubitId, outcome);
 }
 
+// returns 1 if successful, else 0
 void statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], QuESTEnv env){
     long long int chunkSize, stateVecSize;
     long long int indexInChunk, totalIndex;
@@ -464,6 +465,9 @@ void statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], 
     char line[200];
 
     fp = fopen(filename, "r");
+	if (fp == NULL)
+		return 0;
+	
     indexInChunk = 0; totalIndex = 0;
     while (fgets(line, sizeof(char)*200, fp) != NULL && totalIndex<stateVecSize){
         if (line[0]!='#'){
@@ -485,8 +489,10 @@ void statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], 
         }
     }
     fclose(fp);
-
     copyStateToGPU(*qureg);
+	
+	// indicate success
+	return 1;
 }
 
 int statevec_compareStates(QubitRegister mq1, QubitRegister mq2, REAL precision){

--- a/QuEST/GPU/QuEST_gpu.cu
+++ b/QuEST/GPU/QuEST_gpu.cu
@@ -560,7 +560,7 @@ __global__ void statevec_compactUnitaryKernel (QubitRegister qureg, const int ro
 void statevec_compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta) 
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
+    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
     int threadsPerCUDABlock, CUDABlocks;
     threadsPerCUDABlock = 128;
     CUDABlocks = ceil((REAL)(qureg.numAmpsPerChunk>>1)/threadsPerCUDABlock);
@@ -631,7 +631,7 @@ void statevec_controlledCompactUnitary(QubitRegister qureg, const int controlQub
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(validateAlphaBeta(alpha, beta), 6, __func__);
+    QuESTAssert(isComplexPairUnitary(alpha, beta), 6, __func__);
 
     int threadsPerCUDABlock, CUDABlocks;
     threadsPerCUDABlock = 128;
@@ -695,7 +695,7 @@ __global__ void statevec_unitaryKernel(QubitRegister qureg, const int targetQubi
 void statevec_unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u)
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
     int threadsPerCUDABlock, CUDABlocks;
     threadsPerCUDABlock = 128;
     CUDABlocks = ceil((REAL)(qureg.numAmpsPerChunk>>1)/threadsPerCUDABlock);
@@ -765,7 +765,7 @@ void statevec_controlledUnitary(QubitRegister qureg, const int controlQubit, con
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(controlQubit >= 0 && controlQubit < qureg.numQubitsInStateVec, 2, __func__);
     QuESTAssert(controlQubit != targetQubit, 3, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
 
     int threadsPerCUDABlock, CUDABlocks;
     threadsPerCUDABlock = 128;
@@ -833,7 +833,7 @@ void statevec_multiControlledUnitary(QubitRegister qureg, int *controlQubits, in
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
     QuESTAssert(numControlQubits > 0 && numControlQubits <= qureg.numQubitsInStateVec, 4, __func__);
-    QuESTAssert(validateMatrixIsUnitary(u), 5, __func__);
+    QuESTAssert(isMatrixUnitary(u), 5, __func__);
     int threadsPerCUDABlock, CUDABlocks;
     long long int mask=0;
     for (int i=0; i<numControlQubits; i++) mask = mask | (1LL<<controlQubits[i]);
@@ -1035,7 +1035,7 @@ __global__ void statevec_phaseShiftByTermKernel(QubitRegister qureg, const int t
 void statevec_phaseShiftByTerm(QubitRegister qureg, const int targetQubit, Complex term)
 {
     QuESTAssert(targetQubit >= 0 && targetQubit < qureg.numQubitsInStateVec, 1, __func__);
-	QuESTAssert(validateUnitComplex(term), 16, __func__);
+	QuESTAssert(isComplexUnit(term), 16, __func__);
 	
 	REAL cosAngle = term.real;
 	REAL sinAngle = term.imag;

--- a/QuEST/GPU/QuEST_gpu.cu
+++ b/QuEST/GPU/QuEST_gpu.cu
@@ -451,7 +451,7 @@ void statevec_initStateOfSingleQubit(QubitRegister *qureg, int qubitId, int outc
 }
 
 // returns 1 if successful, else 0
-void statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], QuESTEnv env){
+int statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], QuESTEnv env){
     long long int chunkSize, stateVecSize;
     long long int indexInChunk, totalIndex;
 

--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -467,7 +467,17 @@ void initStateDebug(QubitRegister qureg) {
 
 // @TODO
 void initStateFromSingleFile(QubitRegister *qureg, char filename[200], QuESTEnv env) {
-	statevec_initStateFromSingleFile(qureg, filename, env);
+	
+	int success = 0;
+	
+	// @TODO allow density matrix loading from file
+	if (qureg->isDensityMatrix)
+		validateStateVecQureg(*qureg, __func__);
+	
+	else
+		success = statevec_initStateFromSingleFile(qureg, filename, env);
+	
+	validateFileOpened(success, __func__);
 }
 
 // @TODO

--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -424,53 +424,44 @@ void initPureState(QubitRegister qureg, QubitRegister pure) {
 
 
 
-// @TODO
+// @TODO implement densmatr_collapseToKnownProbOutcome(qureg, measureQubit, outcome, outcomeProb);
 REAL collapseToOutcome(QubitRegister qureg, const int measureQubit, int outcome) {
 	validateTarget(qureg, measureQubit); // should rename? eh
 	validateOutcome(outcome);
-
-	if (qureg.isDensityMatrix) {
-		printf("ERROR: collapseToOutcome YET IMPLEMENTED FOR DENSITY MATRICES");
-		exit(1);
-	}	
 	
-	/*
-	capture probability of collapse and validate here? Or just let it be caught internally?
-	*/
+	REAL outcomeProb;
+	if (qureg.isDensityMatrix) {
+		outcomeProb = densmatr_findProbabilityOfOutcome(qureg, measureQubit, outcome);
+		validateMeasurementProb(outcomeProb);
+		densmatr_collapseToKnownProbOutcome(qureg, measureQubit, outcome, outcomeProb);
+	} else {
+		outcomeProb = statevec_findProbabilityOfOutcome(qureg, measureQubit, outcome);
+		validateMeasurementProb(outcomeProb);
+		statevec_collapseToKnownProbOutcome(qureg, measureQubit, outcome, outcomeProb);
+	}
 
-	return statevec_collapseToOutcome(qureg, measureQubit, outcome);
+	return outcomeProb;
 }
 
-// @TODO
+int measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb) {
+	validateTarget(qureg, measureQubit); // should rename? eh
+
+	if (qureg.isDensityMatrix)
+		return densmatr_measureWithStats(qureg, measureQubit, outcomeProb);
+	else
+		return statevec_measureWithStats(qureg, measureQubit, outcomeProb);
+}
+
+
 int measure(QubitRegister qureg, int measureQubit) {
 	validateTarget(qureg, measureQubit); // should rename? eh
 	
-	if (qureg.isDensityMatrix) {
-		printf("ERROR: measure YET IMPLEMENTED FOR DENSITY MATRICES");
-		exit(1);
-	}
-	
-	return statevec_measure(qureg, measureQubit);
+	REAL discardedProb;
+	if (qureg.isDensityMatrix)
+		return densmatr_measureWithStats(qureg, measureQubit, &discardedProb);
+	else
+		return statevec_measureWithStats(qureg, measureQubit, &discardedProb);
 }
-
-// @TODO
-int measureWithStats(QubitRegister qureg, int measureQubit, REAL *stateProb) {
-	validateTarget(qureg, measureQubit); // should rename? eh
-
-
-	if (qureg.isDensityMatrix) {
-		printf("ERROR: measureWithStates NOT YET IMPLEMENTED FOR DENSITY MATRICES");
-		exit(1);
-	}	
-	
-	/*
-	capture probability of collapse and validate here? Or just let it be caught internally?
-	*/
-
-	return statevec_measureWithStats(qureg, measureQubit, stateProb);
-}
-
-
 
 
 

--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -392,26 +392,15 @@ REAL findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int o
 }
 
 
-
-
-
-
-
-
-
 // @TODO add density copying to distributed CPU
 void initPureState(QubitRegister qureg, QubitRegister pure) {
-	
-	// validation here that second arg is a state-vector
-	
-	if (qureg.isDensityMatrix) {
-		QuESTAssert(qureg.numQubitsRepresented==pure.numQubitsInStateVec, 13, __func__);
+	validateSecondQuregStateVec(pure);
+	validateMatchingQuregDims(qureg, pure);
+
+	if (qureg.isDensityMatrix)
 		densmatr_initPureState(qureg, pure);
-		
-	} else {
-		QuESTAssert(qureg.numQubitsInStateVec==pure.numQubitsInStateVec, 13, __func__);
+	else
 		statevec_initPureState(qureg, pure);
-	}
 }
 
 

--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -64,7 +64,7 @@ void initStatePlus(QubitRegister qureg) {
 }
 
 void initClassicalState(QubitRegister qureg, long long int stateInd) {
-	QuESTAssert(stateInd>=0 && stateInd<qureg.numAmpsTotal, E_INVALID_STATE_INDEX, __func__);
+	validateStateIndex(qureg, stateInd);
 	
 	if (qureg.isDensityMatrix)
 		densmatr_initClassicalState(qureg, stateInd);
@@ -73,7 +73,7 @@ void initClassicalState(QubitRegister qureg, long long int stateInd) {
 }
 
 void hadamard(QubitRegister qureg, const int targetQubit) {
-	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+	validateTarget(qureg, targetQubit);
 
 	statevec_hadamard(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -82,7 +82,7 @@ void hadamard(QubitRegister qureg, const int targetQubit) {
 }
 
 void rotateX(QubitRegister qureg, const int targetQubit, REAL angle) {
-	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+	validateTarget(qureg, targetQubit);
 	
 	statevec_rotateX(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -91,7 +91,7 @@ void rotateX(QubitRegister qureg, const int targetQubit, REAL angle) {
 }
 
 void rotateY(QubitRegister qureg, const int targetQubit, REAL angle) {
-	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+	validateTarget(qureg, targetQubit);
 	
 	statevec_rotateY(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -100,7 +100,7 @@ void rotateY(QubitRegister qureg, const int targetQubit, REAL angle) {
 }
 
 void rotateZ(QubitRegister qureg, const int targetQubit, REAL angle) {
-	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+	validateTarget(qureg, targetQubit);
 	
 	statevec_rotateZ(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -109,8 +109,7 @@ void rotateZ(QubitRegister qureg, const int targetQubit, REAL angle) {
 }
 
 void controlledRotateX(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle) {
-	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
-	QuESTAssert(controlQubit>=0 && controlQubit<qureg.numQubitsRepresented, E_INVALID_CONTROL_QUBIT, __func__);
+	validateControlTarget(qureg, controlQubit, targetQubit);
 	
 	statevec_controlledRotateX(qureg, controlQubit, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -120,6 +119,8 @@ void controlledRotateX(QubitRegister qureg, const int controlQubit, const int ta
 }
 
 void controlledRotateY(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle) {
+	validateControlTarget(qureg, controlQubit, targetQubit);
+	
 	statevec_controlledRotateY(qureg, controlQubit, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -128,6 +129,8 @@ void controlledRotateY(QubitRegister qureg, const int controlQubit, const int ta
 }
 
 void controlledRotateZ(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle) {
+	validateControlTarget(qureg, controlQubit, targetQubit);
+	
 	statevec_controlledRotateZ(qureg, controlQubit, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -136,6 +139,9 @@ void controlledRotateZ(QubitRegister qureg, const int controlQubit, const int ta
 }
 
 void unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u) {
+	validateTarget(qureg, targetQubit);
+	
+	
 	statevec_unitary(qureg, targetQubit, u);
 	if (qureg.isDensityMatrix) {
 		statevec_unitary(qureg, targetQubit+qureg.numQubitsRepresented, getConjugateMatrix(u));

--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -31,7 +31,7 @@ extern "C" {
 #endif
 
 void createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv env) {
-	validateCreateNumQubits(numQubits);
+	validateCreateNumQubits(numQubits, __func__);
 	
 	statevec_createQubitRegister(qureg, numQubits, env);
 	qureg->isDensityMatrix = 0;
@@ -40,7 +40,7 @@ void createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv env) {
 }
 
 void createDensityQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv env) {
-	validateCreateNumQubits(numQubits);
+	validateCreateNumQubits(numQubits, __func__);
 	
 	statevec_createQubitRegister(qureg, 2*numQubits, env);
 	qureg->isDensityMatrix = 1;
@@ -64,7 +64,7 @@ void initStatePlus(QubitRegister qureg) {
 }
 
 void initClassicalState(QubitRegister qureg, long long int stateInd) {
-	validateStateIndex(qureg, stateInd);
+	validateStateIndex(qureg, stateInd, __func__);
 	
 	if (qureg.isDensityMatrix)
 		densmatr_initClassicalState(qureg, stateInd);
@@ -73,7 +73,7 @@ void initClassicalState(QubitRegister qureg, long long int stateInd) {
 }
 
 void hadamard(QubitRegister qureg, const int targetQubit) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 
 	statevec_hadamard(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -82,7 +82,7 @@ void hadamard(QubitRegister qureg, const int targetQubit) {
 }
 
 void rotateX(QubitRegister qureg, const int targetQubit, REAL angle) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_rotateX(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -91,7 +91,7 @@ void rotateX(QubitRegister qureg, const int targetQubit, REAL angle) {
 }
 
 void rotateY(QubitRegister qureg, const int targetQubit, REAL angle) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_rotateY(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -100,7 +100,7 @@ void rotateY(QubitRegister qureg, const int targetQubit, REAL angle) {
 }
 
 void rotateZ(QubitRegister qureg, const int targetQubit, REAL angle) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_rotateZ(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -109,7 +109,7 @@ void rotateZ(QubitRegister qureg, const int targetQubit, REAL angle) {
 }
 
 void controlledRotateX(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle) {
-	validateControlTarget(qureg, controlQubit, targetQubit);
+	validateControlTarget(qureg, controlQubit, targetQubit, __func__);
 	
 	statevec_controlledRotateX(qureg, controlQubit, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -119,7 +119,7 @@ void controlledRotateX(QubitRegister qureg, const int controlQubit, const int ta
 }
 
 void controlledRotateY(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle) {
-	validateControlTarget(qureg, controlQubit, targetQubit);
+	validateControlTarget(qureg, controlQubit, targetQubit, __func__);
 	
 	statevec_controlledRotateY(qureg, controlQubit, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -129,7 +129,7 @@ void controlledRotateY(QubitRegister qureg, const int controlQubit, const int ta
 }
 
 void controlledRotateZ(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle) {
-	validateControlTarget(qureg, controlQubit, targetQubit);
+	validateControlTarget(qureg, controlQubit, targetQubit, __func__);
 	
 	statevec_controlledRotateZ(qureg, controlQubit, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -139,8 +139,8 @@ void controlledRotateZ(QubitRegister qureg, const int controlQubit, const int ta
 }
 
 void unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u) {
-	validateTarget(qureg, targetQubit);
-	validateUnitaryMatrix(u);
+	validateTarget(qureg, targetQubit, __func__);
+	validateUnitaryMatrix(u, __func__);
 	
 	statevec_unitary(qureg, targetQubit, u);
 	if (qureg.isDensityMatrix) {
@@ -149,8 +149,8 @@ void unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u) {
 }
 
 void controlledUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, ComplexMatrix2 u) {
-	validateControlTarget(qureg, controlQubit, targetQubit);
-	validateUnitaryMatrix(u);
+	validateControlTarget(qureg, controlQubit, targetQubit, __func__);
+	validateUnitaryMatrix(u, __func__);
 	
 	statevec_controlledUnitary(qureg, controlQubit, targetQubit, u);
 	if (qureg.isDensityMatrix) {
@@ -160,8 +160,8 @@ void controlledUnitary(QubitRegister qureg, const int controlQubit, const int ta
 }
 
 void multiControlledUnitary(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, ComplexMatrix2 u) {
-	validateMultiControlsTarget(qureg, controlQubits, numControlQubits, targetQubit);
-	validateUnitaryMatrix(u);
+	validateMultiControlsTarget(qureg, controlQubits, numControlQubits, targetQubit, __func__);
+	validateUnitaryMatrix(u, __func__);
 	
 	statevec_multiControlledUnitary(qureg, controlQubits, numControlQubits, targetQubit, u);
 	if (qureg.isDensityMatrix) {
@@ -173,8 +173,8 @@ void multiControlledUnitary(QubitRegister qureg, int* controlQubits, const int n
 }
 
 void compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta) {
-	validateTarget(qureg, targetQubit);
-	validateUnitaryComplexPair(alpha, beta);
+	validateTarget(qureg, targetQubit, __func__);
+	validateUnitaryComplexPair(alpha, beta, __func__);
 	
 	statevec_compactUnitary(qureg, targetQubit, alpha, beta);
 	if (qureg.isDensityMatrix) {
@@ -184,8 +184,8 @@ void compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, C
 }
 
 void controlledCompactUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, Complex alpha, Complex beta) {
-	validateControlTarget(qureg, controlQubit, targetQubit);
-	validateUnitaryComplexPair(alpha, beta);
+	validateControlTarget(qureg, controlQubit, targetQubit, __func__);
+	validateUnitaryComplexPair(alpha, beta, __func__);
 	
 	statevec_controlledCompactUnitary(qureg, controlQubit, targetQubit, alpha, beta);
 	if (qureg.isDensityMatrix) {
@@ -197,7 +197,7 @@ void controlledCompactUnitary(QubitRegister qureg, const int controlQubit, const
 }
 
 void sigmaX(QubitRegister qureg, const int targetQubit) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_sigmaX(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -206,7 +206,7 @@ void sigmaX(QubitRegister qureg, const int targetQubit) {
 }
 
 void sigmaY(QubitRegister qureg, const int targetQubit) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_sigmaY(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -215,7 +215,7 @@ void sigmaY(QubitRegister qureg, const int targetQubit) {
 }
 
 void sigmaZ(QubitRegister qureg, const int targetQubit) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_sigmaZ(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -224,7 +224,7 @@ void sigmaZ(QubitRegister qureg, const int targetQubit) {
 }
 
 void sGate(QubitRegister qureg, const int targetQubit) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_sGate(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -233,7 +233,7 @@ void sGate(QubitRegister qureg, const int targetQubit) {
 }
 
 void tGate(QubitRegister qureg, const int targetQubit) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_tGate(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -242,7 +242,7 @@ void tGate(QubitRegister qureg, const int targetQubit) {
 }
 
 void phaseShift(QubitRegister qureg, const int targetQubit, REAL angle) {
-	validateTarget(qureg, targetQubit);
+	validateTarget(qureg, targetQubit, __func__);
 	
 	statevec_phaseShift(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
@@ -251,7 +251,7 @@ void phaseShift(QubitRegister qureg, const int targetQubit, REAL angle) {
 }
 
 void controlledPhaseShift(QubitRegister qureg, const int idQubit1, const int idQubit2, REAL angle) {
-	validateControlTarget(qureg, idQubit1, idQubit2); // a little bit semantically dodgy
+	validateControlTarget(qureg, idQubit1, idQubit2, __func__); // a little bit semantically dodgy
 	
 	statevec_controlledPhaseShift(qureg, idQubit1, idQubit2, angle);
 	if (qureg.isDensityMatrix) {
@@ -261,7 +261,7 @@ void controlledPhaseShift(QubitRegister qureg, const int idQubit1, const int idQ
 }
 
 void multiControlledPhaseShift(QubitRegister qureg, int *controlQubits, int numControlQubits, REAL angle) {
-	validateMultiControls(qureg, controlQubits, numControlQubits);
+	validateMultiControls(qureg, controlQubits, numControlQubits, __func__);
 	
 	statevec_multiControlledPhaseShift(qureg, controlQubits, numControlQubits, angle);
 	if (qureg.isDensityMatrix) {
@@ -273,7 +273,7 @@ void multiControlledPhaseShift(QubitRegister qureg, int *controlQubits, int numC
 }
 
 void controlledNot(QubitRegister qureg, const int controlQubit, const int targetQubit) {
-	validateControlTarget(qureg, controlQubit, targetQubit);
+	validateControlTarget(qureg, controlQubit, targetQubit, __func__);
 	
 	statevec_controlledNot(qureg, controlQubit, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -283,7 +283,7 @@ void controlledNot(QubitRegister qureg, const int controlQubit, const int target
 }
 
 void controlledSigmaY(QubitRegister qureg, const int controlQubit, const int targetQubit) {
-	validateControlTarget(qureg, controlQubit, targetQubit);
+	validateControlTarget(qureg, controlQubit, targetQubit, __func__);
 	
 	statevec_controlledSigmaY(qureg, controlQubit, targetQubit);
 	if (qureg.isDensityMatrix) {
@@ -293,7 +293,7 @@ void controlledSigmaY(QubitRegister qureg, const int controlQubit, const int tar
 }
 
 void controlledPhaseFlip(QubitRegister qureg, const int idQubit1, const int idQubit2) {
-	validateControlTarget(qureg, idQubit1, idQubit2); // a little bit semantically dodgy
+	validateControlTarget(qureg, idQubit1, idQubit2, __func__); // a little bit semantically dodgy
 	
 	statevec_controlledPhaseFlip(qureg, idQubit1, idQubit2);
 	if (qureg.isDensityMatrix) {
@@ -303,7 +303,7 @@ void controlledPhaseFlip(QubitRegister qureg, const int idQubit1, const int idQu
 }
 
 void multiControlledPhaseFlip(QubitRegister qureg, int *controlQubits, int numControlQubits) {
-	validateMultiControls(qureg, controlQubits, numControlQubits);
+	validateMultiControls(qureg, controlQubits, numControlQubits, __func__);
 	
 	statevec_multiControlledPhaseFlip(qureg, controlQubits, numControlQubits);
 	if (qureg.isDensityMatrix) {
@@ -315,8 +315,8 @@ void multiControlledPhaseFlip(QubitRegister qureg, int *controlQubits, int numCo
 }
 
 void rotateAroundAxis(QubitRegister qureg, const int rotQubit, REAL angle, Vector axis) {
-	validateTarget(qureg, rotQubit);
-	validateVector(axis);
+	validateTarget(qureg, rotQubit, __func__);
+	validateVector(axis, __func__);
 	
 	statevec_rotateAroundAxis(qureg, rotQubit, angle, axis);
 	if (qureg.isDensityMatrix) {
@@ -326,8 +326,8 @@ void rotateAroundAxis(QubitRegister qureg, const int rotQubit, REAL angle, Vecto
 }
 
 void controlledRotateAroundAxis(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle, Vector axis) {
-	validateControlTarget(qureg, controlQubit, targetQubit);
-	validateVector(axis);
+	validateControlTarget(qureg, controlQubit, targetQubit, __func__);
+	validateVector(axis, __func__);
 	
 	statevec_controlledRotateAroundAxis(qureg, controlQubit, targetQubit, angle, axis);
 	if (qureg.isDensityMatrix) {
@@ -341,35 +341,35 @@ int getNumQubits(QubitRegister qureg) {
 }
 
 int getNumAmps(QubitRegister qureg) {
-	validateStateVecQureg(qureg);
+	validateStateVecQureg(qureg, __func__);
 	
 	return qureg.numAmpsTotal;
 }
 
 REAL getRealAmpEl(QubitRegister qureg, long long int index) {
-	validateStateVecQureg(qureg);
-	validateStateIndex(qureg, index);
+	validateStateVecQureg(qureg, __func__);
+	validateStateIndex(qureg, index, __func__);
 	
 	return statevec_getRealAmpEl(qureg, index);
 }
 
 REAL getImagAmpEl(QubitRegister qureg, long long int index) {
-	validateStateVecQureg(qureg);
-	validateStateIndex(qureg, index);
+	validateStateVecQureg(qureg, __func__);
+	validateStateIndex(qureg, index, __func__);
 	
 	return statevec_getImagAmpEl(qureg, index);
 }
 
 REAL getProbEl(QubitRegister qureg, long long int index) {
-	validateStateVecQureg(qureg);
-	validateStateIndex(qureg, index);
+	validateStateVecQureg(qureg, __func__);
+	validateStateIndex(qureg, index, __func__);
 	
 	return statevec_getProbEl(qureg, index);
 }
 
 int compareStates(QubitRegister mq1, QubitRegister mq2, REAL precision) {
-	validateStateVecQureg(mq1);
-	validateStateVecQureg(mq2);
+	validateStateVecQureg(mq1, __func__);
+	validateStateVecQureg(mq2, __func__);
 	
 	return statevec_compareStates(mq1, mq2, precision);
 }
@@ -382,8 +382,8 @@ REAL calcTotalProbability(QubitRegister qureg) {
 }
 
 REAL findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int outcome) {
-	validateTarget(qureg, measureQubit); // should rename? meh
-	validateOutcome(outcome);
+	validateTarget(qureg, measureQubit, __func__); // should rename? meh
+	validateOutcome(outcome, __func__);
 	
 	if (qureg.isDensityMatrix)
 		return densmatr_findProbabilityOfOutcome(qureg, measureQubit, outcome);
@@ -394,8 +394,8 @@ REAL findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int o
 
 // @TODO add density copying to distributed CPU
 void initPureState(QubitRegister qureg, QubitRegister pure) {
-	validateSecondQuregStateVec(pure);
-	validateMatchingQuregDims(qureg, pure);
+	validateSecondQuregStateVec(pure, __func__);
+	validateMatchingQuregDims(qureg, pure, __func__);
 
 	if (qureg.isDensityMatrix)
 		densmatr_initPureState(qureg, pure);
@@ -415,17 +415,17 @@ void initPureState(QubitRegister qureg, QubitRegister pure) {
 
 // @TODO implement densmatr_collapseToKnownProbOutcome(qureg, measureQubit, outcome, outcomeProb);
 REAL collapseToOutcome(QubitRegister qureg, const int measureQubit, int outcome) {
-	validateTarget(qureg, measureQubit); // should rename? eh
-	validateOutcome(outcome);
+	validateTarget(qureg, measureQubit, __func__); // should rename? eh
+	validateOutcome(outcome, __func__);
 	
 	REAL outcomeProb;
 	if (qureg.isDensityMatrix) {
 		outcomeProb = densmatr_findProbabilityOfOutcome(qureg, measureQubit, outcome);
-		validateMeasurementProb(outcomeProb);
+		validateMeasurementProb(outcomeProb, __func__);
 		densmatr_collapseToKnownProbOutcome(qureg, measureQubit, outcome, outcomeProb);
 	} else {
 		outcomeProb = statevec_findProbabilityOfOutcome(qureg, measureQubit, outcome);
-		validateMeasurementProb(outcomeProb);
+		validateMeasurementProb(outcomeProb, __func__);
 		statevec_collapseToKnownProbOutcome(qureg, measureQubit, outcome, outcomeProb);
 	}
 
@@ -433,7 +433,7 @@ REAL collapseToOutcome(QubitRegister qureg, const int measureQubit, int outcome)
 }
 
 int measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb) {
-	validateTarget(qureg, measureQubit); // should rename? eh
+	validateTarget(qureg, measureQubit, __func__); // should rename? eh
 
 	if (qureg.isDensityMatrix)
 		return densmatr_measureWithStats(qureg, measureQubit, outcomeProb);
@@ -443,7 +443,7 @@ int measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb) {
 
 
 int measure(QubitRegister qureg, int measureQubit) {
-	validateTarget(qureg, measureQubit); // should rename? eh
+	validateTarget(qureg, measureQubit, __func__); // should rename? eh
 	
 	REAL discardedProb;
 	if (qureg.isDensityMatrix)

--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -17,6 +17,7 @@
 # include "QuEST.h"
 # include "QuEST_internal.h"
 # include "QuEST_precision.h"
+# include "QuEST_validation.h"
 # include "QuEST_ops.h"
 
 
@@ -72,39 +73,45 @@ void initClassicalState(QubitRegister qureg, long long int stateInd) {
 }
 
 void hadamard(QubitRegister qureg, const int targetQubit) {
-	//QuESTAssert(targetQubit>=0 && targetQubit<qureg.numAmpsTotal, E_INVALID_STATE_INDEX, __func__);
-	/*
-	we need a representation agnostic field for the qubit
-	*/
-	
+	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+
 	statevec_hadamard(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
 		statevec_hadamard(qureg, targetQubit+qureg.numQubitsRepresented);
 	}
 }
 
-void rotateX(QubitRegister qureg, const int rotQubit, REAL angle) {
-	statevec_rotateX(qureg, rotQubit, angle);
+void rotateX(QubitRegister qureg, const int targetQubit, REAL angle) {
+	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+	
+	statevec_rotateX(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
-		statevec_rotateX(qureg, rotQubit+qureg.numQubitsRepresented, -angle);
+		statevec_rotateX(qureg, targetQubit+qureg.numQubitsRepresented, -angle);
 	}
 }
 
-void rotateY(QubitRegister qureg, const int rotQubit, REAL angle) {
-	statevec_rotateY(qureg, rotQubit, angle);
+void rotateY(QubitRegister qureg, const int targetQubit, REAL angle) {
+	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+	
+	statevec_rotateY(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
-		statevec_rotateY(qureg, rotQubit+qureg.numQubitsRepresented, angle);
+		statevec_rotateY(qureg, targetQubit+qureg.numQubitsRepresented, angle);
 	}
 }
 
-void rotateZ(QubitRegister qureg, const int rotQubit, REAL angle) {
-	statevec_rotateZ(qureg, rotQubit, angle);
+void rotateZ(QubitRegister qureg, const int targetQubit, REAL angle) {
+	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+	
+	statevec_rotateZ(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
-		statevec_rotateZ(qureg, rotQubit+qureg.numQubitsRepresented, -angle);
+		statevec_rotateZ(qureg, targetQubit+qureg.numQubitsRepresented, -angle);
 	}
 }
 
 void controlledRotateX(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle) {
+	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, __func__);
+	QuESTAssert(controlQubit>=0 && controlQubit<qureg.numQubitsRepresented, E_INVALID_CONTROL_QUBIT, __func__);
+	
 	statevec_controlledRotateX(qureg, controlQubit, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;

--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -31,7 +31,7 @@ extern "C" {
 #endif
 
 void createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv env) {
-	QuESTAssert(numQubits>0, E_INVALID_NUM_QUBITS, __func__);
+	validateCreateNumQubits(numQubits);
 	
 	statevec_createQubitRegister(qureg, numQubits, env);
 	qureg->isDensityMatrix = 0;
@@ -40,7 +40,7 @@ void createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv env) {
 }
 
 void createDensityQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv env) {
-	QuESTAssert(numQubits>0, E_INVALID_NUM_QUBITS, __func__);
+	validateCreateNumQubits(numQubits);
 	
 	statevec_createQubitRegister(qureg, 2*numQubits, env);
 	qureg->isDensityMatrix = 1;
@@ -140,7 +140,7 @@ void controlledRotateZ(QubitRegister qureg, const int controlQubit, const int ta
 
 void unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u) {
 	validateTarget(qureg, targetQubit);
-	
+	validateUnitaryMatrix(u);
 	
 	statevec_unitary(qureg, targetQubit, u);
 	if (qureg.isDensityMatrix) {
@@ -149,6 +149,9 @@ void unitary(QubitRegister qureg, const int targetQubit, ComplexMatrix2 u) {
 }
 
 void controlledUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, ComplexMatrix2 u) {
+	validateControlTarget(qureg, controlQubit, targetQubit);
+	validateUnitaryMatrix(u);
+	
 	statevec_controlledUnitary(qureg, controlQubit, targetQubit, u);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -157,6 +160,9 @@ void controlledUnitary(QubitRegister qureg, const int controlQubit, const int ta
 }
 
 void multiControlledUnitary(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, ComplexMatrix2 u) {
+	validateMultiControlsTarget(qureg, controlQubits, numControlQubits, targetQubit);
+	validateUnitaryMatrix(u);
+	
 	statevec_multiControlledUnitary(qureg, controlQubits, numControlQubits, targetQubit, u);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -167,6 +173,9 @@ void multiControlledUnitary(QubitRegister qureg, int* controlQubits, const int n
 }
 
 void compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, Complex beta) {
+	validateTarget(qureg, targetQubit);
+	validateUnitaryComplexPair(alpha, beta);
+	
 	statevec_compactUnitary(qureg, targetQubit, alpha, beta);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -175,6 +184,9 @@ void compactUnitary(QubitRegister qureg, const int targetQubit, Complex alpha, C
 }
 
 void controlledCompactUnitary(QubitRegister qureg, const int controlQubit, const int targetQubit, Complex alpha, Complex beta) {
+	validateControlTarget(qureg, controlQubit, targetQubit);
+	validateUnitaryComplexPair(alpha, beta);
+	
 	statevec_controlledCompactUnitary(qureg, controlQubit, targetQubit, alpha, beta);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -185,6 +197,8 @@ void controlledCompactUnitary(QubitRegister qureg, const int controlQubit, const
 }
 
 void sigmaX(QubitRegister qureg, const int targetQubit) {
+	validateTarget(qureg, targetQubit);
+	
 	statevec_sigmaX(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
 		statevec_sigmaX(qureg, targetQubit+qureg.numQubitsRepresented);
@@ -192,6 +206,8 @@ void sigmaX(QubitRegister qureg, const int targetQubit) {
 }
 
 void sigmaY(QubitRegister qureg, const int targetQubit) {
+	validateTarget(qureg, targetQubit);
+	
 	statevec_sigmaY(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
 		statevec_sigmaYConj(qureg, targetQubit + qureg.numQubitsRepresented);
@@ -199,6 +215,8 @@ void sigmaY(QubitRegister qureg, const int targetQubit) {
 }
 
 void sigmaZ(QubitRegister qureg, const int targetQubit) {
+	validateTarget(qureg, targetQubit);
+	
 	statevec_sigmaZ(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
 		statevec_sigmaZ(qureg, targetQubit+qureg.numQubitsRepresented);
@@ -206,6 +224,8 @@ void sigmaZ(QubitRegister qureg, const int targetQubit) {
 }
 
 void sGate(QubitRegister qureg, const int targetQubit) {
+	validateTarget(qureg, targetQubit);
+	
 	statevec_sGate(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
 		statevec_sGateConj(qureg, targetQubit+qureg.numQubitsRepresented);
@@ -213,6 +233,8 @@ void sGate(QubitRegister qureg, const int targetQubit) {
 }
 
 void tGate(QubitRegister qureg, const int targetQubit) {
+	validateTarget(qureg, targetQubit);
+	
 	statevec_tGate(qureg, targetQubit);
 	if (qureg.isDensityMatrix) {
 		statevec_tGateConj(qureg, targetQubit+qureg.numQubitsRepresented);
@@ -220,6 +242,8 @@ void tGate(QubitRegister qureg, const int targetQubit) {
 }
 
 void phaseShift(QubitRegister qureg, const int targetQubit, REAL angle) {
+	validateTarget(qureg, targetQubit);
+	
 	statevec_phaseShift(qureg, targetQubit, angle);
 	if (qureg.isDensityMatrix) {
 		statevec_phaseShift(qureg, targetQubit+qureg.numQubitsRepresented, -angle);
@@ -227,6 +251,8 @@ void phaseShift(QubitRegister qureg, const int targetQubit, REAL angle) {
 }
 
 void controlledPhaseShift(QubitRegister qureg, const int idQubit1, const int idQubit2, REAL angle) {
+	validateControlTarget(qureg, idQubit1, idQubit2); // a little bit semantically dodgy
+	
 	statevec_controlledPhaseShift(qureg, idQubit1, idQubit2, angle);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -235,6 +261,8 @@ void controlledPhaseShift(QubitRegister qureg, const int idQubit1, const int idQ
 }
 
 void multiControlledPhaseShift(QubitRegister qureg, int *controlQubits, int numControlQubits, REAL angle) {
+	validateMultiControls(qureg, controlQubits, numControlQubits);
+	
 	statevec_multiControlledPhaseShift(qureg, controlQubits, numControlQubits, angle);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -245,6 +273,8 @@ void multiControlledPhaseShift(QubitRegister qureg, int *controlQubits, int numC
 }
 
 void controlledNot(QubitRegister qureg, const int controlQubit, const int targetQubit) {
+	validateControlTarget(qureg, controlQubit, targetQubit);
+	
 	statevec_controlledNot(qureg, controlQubit, targetQubit);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -253,6 +283,8 @@ void controlledNot(QubitRegister qureg, const int controlQubit, const int target
 }
 
 void controlledSigmaY(QubitRegister qureg, const int controlQubit, const int targetQubit) {
+	validateControlTarget(qureg, controlQubit, targetQubit);
+	
 	statevec_controlledSigmaY(qureg, controlQubit, targetQubit);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -261,6 +293,8 @@ void controlledSigmaY(QubitRegister qureg, const int controlQubit, const int tar
 }
 
 void controlledPhaseFlip(QubitRegister qureg, const int idQubit1, const int idQubit2) {
+	validateControlTarget(qureg, idQubit1, idQubit2); // a little bit semantically dodgy
+	
 	statevec_controlledPhaseFlip(qureg, idQubit1, idQubit2);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -269,6 +303,8 @@ void controlledPhaseFlip(QubitRegister qureg, const int idQubit1, const int idQu
 }
 
 void multiControlledPhaseFlip(QubitRegister qureg, int *controlQubits, int numControlQubits) {
+	validateMultiControls(qureg, controlQubits, numControlQubits);
+	
 	statevec_multiControlledPhaseFlip(qureg, controlQubits, numControlQubits);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -279,6 +315,9 @@ void multiControlledPhaseFlip(QubitRegister qureg, int *controlQubits, int numCo
 }
 
 void rotateAroundAxis(QubitRegister qureg, const int rotQubit, REAL angle, Vector axis) {
+	validateTarget(qureg, rotQubit);
+	validateVector(axis);
+	
 	statevec_rotateAroundAxis(qureg, rotQubit, angle, axis);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -287,6 +326,9 @@ void rotateAroundAxis(QubitRegister qureg, const int rotQubit, REAL angle, Vecto
 }
 
 void controlledRotateAroundAxis(QubitRegister qureg, const int controlQubit, const int targetQubit, REAL angle, Vector axis) {
+	validateControlTarget(qureg, controlQubit, targetQubit);
+	validateVector(axis);
+	
 	statevec_controlledRotateAroundAxis(qureg, controlQubit, targetQubit, angle, axis);
 	if (qureg.isDensityMatrix) {
 		int shift = qureg.numQubitsRepresented;
@@ -295,35 +337,41 @@ void controlledRotateAroundAxis(QubitRegister qureg, const int controlQubit, con
 }
 
 int getNumQubits(QubitRegister qureg) {
-	if (qureg.isDensityMatrix)
-		return qureg.numQubitsRepresented;
-	else
-		return statevec_getNumQubits(qureg);
-}
-
-int compareStates(QubitRegister mq1, QubitRegister mq2, REAL precision) {
-	QuESTAssert(!mq1.isDensityMatrix && !mq2.isDensityMatrix, 15, __func__);
-	return statevec_compareStates(mq1, mq2, precision);
+	return qureg.numQubitsRepresented;
 }
 
 int getNumAmps(QubitRegister qureg) {
-	QuESTAssert(!qureg.isDensityMatrix, 14, __func__);
-	return statevec_getNumAmps(qureg);
+	validateStateVecQureg(qureg);
+	
+	return qureg.numAmpsTotal;
 }
 
 REAL getRealAmpEl(QubitRegister qureg, long long int index) {
-	QuESTAssert(!qureg.isDensityMatrix, 14, __func__);
+	validateStateVecQureg(qureg);
+	validateStateIndex(qureg, index);
+	
 	return statevec_getRealAmpEl(qureg, index);
 }
 
 REAL getImagAmpEl(QubitRegister qureg, long long int index) {
-	QuESTAssert(!qureg.isDensityMatrix, 14, __func__);
+	validateStateVecQureg(qureg);
+	validateStateIndex(qureg, index);
+	
 	return statevec_getImagAmpEl(qureg, index);
 }
 
 REAL getProbEl(QubitRegister qureg, long long int index) {
-	QuESTAssert(!qureg.isDensityMatrix, 14, __func__);
+	validateStateVecQureg(qureg);
+	validateStateIndex(qureg, index);
+	
 	return statevec_getProbEl(qureg, index);
+}
+
+int compareStates(QubitRegister mq1, QubitRegister mq2, REAL precision) {
+	validateStateVecQureg(mq1);
+	validateStateVecQureg(mq2);
+	
+	return statevec_compareStates(mq1, mq2, precision);
 }
 
 REAL calcTotalProbability(QubitRegister qureg) {
@@ -334,6 +382,9 @@ REAL calcTotalProbability(QubitRegister qureg) {
 }
 
 REAL findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int outcome) {
+	validateTarget(qureg, measureQubit); // should rename? meh
+	validateOutcome(outcome);
+	
 	if (qureg.isDensityMatrix)
 		return densmatr_findProbabilityOfOutcome(qureg, measureQubit, outcome);
 	else
@@ -350,7 +401,8 @@ REAL findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int o
 
 // @TODO add density copying to distributed CPU
 void initPureState(QubitRegister qureg, QubitRegister pure) {
-	QuESTAssert(!pure.isDensityMatrix, 12, __func__);
+	
+	// validation here that second arg is a state-vector
 	
 	if (qureg.isDensityMatrix) {
 		QuESTAssert(qureg.numQubitsRepresented==pure.numQubitsInStateVec, 13, __func__);
@@ -366,7 +418,7 @@ void initPureState(QubitRegister qureg, QubitRegister pure) {
 
 
 
-
+/* simons requested func for cloning density matrices */
 
 
 
@@ -374,20 +426,27 @@ void initPureState(QubitRegister qureg, QubitRegister pure) {
 
 // @TODO
 REAL collapseToOutcome(QubitRegister qureg, const int measureQubit, int outcome) {
+	validateTarget(qureg, measureQubit); // should rename? eh
+	validateOutcome(outcome);
 
 	if (qureg.isDensityMatrix) {
-		printf("ERROR: sigmaY NOT YET IMPLEMENTED FOR DENSITY MATRICES");
+		printf("ERROR: collapseToOutcome YET IMPLEMENTED FOR DENSITY MATRICES");
 		exit(1);
 	}	
+	
+	/*
+	capture probability of collapse and validate here? Or just let it be caught internally?
+	*/
 
 	return statevec_collapseToOutcome(qureg, measureQubit, outcome);
 }
 
 // @TODO
 int measure(QubitRegister qureg, int measureQubit) {
+	validateTarget(qureg, measureQubit); // should rename? eh
 	
 	if (qureg.isDensityMatrix) {
-		printf("ERROR: sigmaY NOT YET IMPLEMENTED FOR DENSITY MATRICES");
+		printf("ERROR: measure YET IMPLEMENTED FOR DENSITY MATRICES");
 		exit(1);
 	}
 	
@@ -396,11 +455,17 @@ int measure(QubitRegister qureg, int measureQubit) {
 
 // @TODO
 int measureWithStats(QubitRegister qureg, int measureQubit, REAL *stateProb) {
+	validateTarget(qureg, measureQubit); // should rename? eh
+
 
 	if (qureg.isDensityMatrix) {
-		printf("ERROR: sigmaY NOT YET IMPLEMENTED FOR DENSITY MATRICES");
+		printf("ERROR: measureWithStates NOT YET IMPLEMENTED FOR DENSITY MATRICES");
 		exit(1);
 	}	
+	
+	/*
+	capture probability of collapse and validate here? Or just let it be caught internally?
+	*/
 
 	return statevec_measureWithStats(qureg, measureQubit, stateProb);
 }

--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -20,12 +20,6 @@
 # include "QuEST_validation.h"
 # include "QuEST_ops.h"
 
-
-// just for debug printing and exiting: can remove later
-# include <stdio.h>
-# include <stdlib.h>
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/QuEST/QuEST.h
+++ b/QuEST/QuEST.h
@@ -56,7 +56,7 @@ typedef struct QubitRegister
 	//! In the non-MPI version, this is the total number of amplitudes
 	long long int numAmpsPerChunk;
 	//! Total number of amplitudes, which are possibly distributed among machines
-	long long int totalNumAmps;
+	long long int numAmpsTotal;
 	//! The position of the chunk of the state vector held by this process in the full state vector
 	int chunkId;
 	//! Number of chunks the state vector is broken up into -- the number of MPI processes used

--- a/QuEST/QuEST.h
+++ b/QuEST/QuEST.h
@@ -55,6 +55,8 @@ typedef struct QubitRegister
 	//! Number of probability amplitudes held in stateVec by this process
 	//! In the non-MPI version, this is the total number of amplitudes
 	long long int numAmpsPerChunk;
+	//! Total number of amplitudes, which are possibly distributed among machines
+	long long int totalNumAmps;
 	//! The position of the chunk of the state vector held by this process in the full state vector
 	int chunkId;
 	//! Number of chunks the state vector is broken up into -- the number of MPI processes used

--- a/QuEST/QuEST.h
+++ b/QuEST/QuEST.h
@@ -1231,12 +1231,12 @@ int measure(QubitRegister qureg, int measureQubit);
  *
  * @param[in, out] qureg object representing the set of all qubits
  * @param[in] measureQubit qubit to measure
- * @param[out] stateProb a pointer to a REAL which is set to the probability of the occurred outcome
+ * @param[out] outcomeProb a pointer to a REAL which is set to the probability of the occurred outcome
  * @return the measurement outcome, 0 or 1
  * @throws exitWithError
  * 		if \p measureQubit is outside [0, \p qureg.numQubits)
  */
-int measureWithStats(QubitRegister qureg, int measureQubit, REAL *stateProb);
+int measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb);
 
 /** Seed the Mersenne Twister used for random number generation in the QuEST environment with an example
  * defualt seed.

--- a/QuEST/QuEST.h
+++ b/QuEST/QuEST.h
@@ -73,8 +73,8 @@ typedef struct QubitRegister
 
 	//! Whether this instance is a density-state representation
 	int isDensityMatrix;
-	// The number of qubits represented in the density matrix, not that suggested by the size of the data-structure
-	int numDensityQubits;
+	//! The number of qubits represented in either the state-vector or density matrix
+	int numQubitsRepresented;
 	
 } QubitRegister;
 

--- a/QuEST/QuEST.h
+++ b/QuEST/QuEST.h
@@ -50,8 +50,8 @@ Qubits are zero-based
 */
 typedef struct QubitRegister
 {
-	//! Number of qubits in the state - double the number represented for mixed states
-	int numQubits;
+	//! Number of qubits in the state-vector - this is double the number represented for mixed states
+	int numQubitsInStateVec;
 	//! Number of probability amplitudes held in stateVec by this process
 	//! In the non-MPI version, this is the total number of amplitudes
 	long long int numAmpsPerChunk;

--- a/QuEST/QuEST_common.c
+++ b/QuEST/QuEST_common.c
@@ -68,9 +68,7 @@ void seedQuEST(unsigned long int *seedArray, int numSeeds){
     init_by_array(seedArray, numSeeds); 
 }
 
-int validateUnitComplex(Complex alpha) {
-	return (absReal(1 - sqrt(alpha.real*alpha.real + alpha.imag*alpha.imag)) < REAL_EPS); 
-}
+
 
 
 

--- a/QuEST/QuEST_common.c
+++ b/QuEST/QuEST_common.c
@@ -25,6 +25,39 @@ extern "C" {
 #endif
 
 
+REAL getVectorMagnitude(Vector vec) {
+	return sqrt(vec.x*vec.x + vec.y*vec.y + vec.z*vec.z);
+}
+
+Vector getUnitVector(Vector vec) {
+	
+	REAL mag = getVectorMagnitude(vec);
+	Vector unitVec = (Vector) {.x=vec.x/mag, .y=vec.y/mag, .z=vec.z/mag};
+	return unitVec;
+}
+
+Complex getConjugateScalar(Complex scalar) {
+	
+	Complex conjScalar;
+	conjScalar.real =   scalar.real;
+	conjScalar.imag = - scalar.imag;
+	return conjScalar;
+}
+
+ComplexMatrix2 getConjugateMatrix(ComplexMatrix2 matrix) {
+	
+	ComplexMatrix2 conjMatrix;
+	conjMatrix.r0c0 = getConjugateScalar(matrix.r0c0);
+	conjMatrix.r0c1 = getConjugateScalar(matrix.r0c1);
+	conjMatrix.r1c0 = getConjugateScalar(matrix.r1c0);
+	conjMatrix.r1c1 = getConjugateScalar(matrix.r1c1);
+	return conjMatrix;
+}
+
+void shiftIndices(int* indices, int numIndices, int shift) {
+	for (int j=0; j < numIndices; j++)
+		indices[j] += shift;
+}
 
 unsigned long int hashString(char *str){
     unsigned long int hash = 5381;
@@ -68,22 +101,10 @@ void seedQuEST(unsigned long int *seedArray, int numSeeds){
     init_by_array(seedArray, numSeeds); 
 }
 
-
-
-
-
 REAL statevec_getProbEl(QubitRegister qureg, long long int index){
     REAL real = statevec_getRealAmpEl(qureg, index);
     REAL imag = statevec_getImagAmpEl(qureg, index);
     return real*real + imag*imag;
-}
-
-int statevec_getNumQubits(QubitRegister qureg){
-    return qureg.numQubitsInStateVec;
-}
-
-int statevec_getNumAmps(QubitRegister qureg){
-    return qureg.numAmpsPerChunk*qureg.numChunks;
 }
 
 void reportState(QubitRegister qureg){
@@ -177,9 +198,7 @@ void statevec_rotateZ(QubitRegister qureg, const int rotQubit, REAL angle){
 
 void getAlphaBetaFromRotation(REAL angle, Vector axis, Complex* alpha, Complex* beta) {
 	
-    REAL mag = sqrt(pow(axis.x,2) + pow(axis.y,2) + pow(axis.z,2));
-    Vector unitAxis = {axis.x/mag, axis.y/mag, axis.z/mag};
-
+    Vector unitAxis = getUnitVector(axis);
     alpha->real =   cos(angle/2.0);
     alpha->imag = - sin(angle/2.0)*unitAxis.z;	
     beta->real  =   sin(angle/2.0)*unitAxis.y;
@@ -236,28 +255,7 @@ void statevec_controlledRotateZ(QubitRegister qureg, const int controlQubit, con
     statevec_controlledRotateAroundAxis(qureg, controlQubit, targetQubit, angle, unitAxis);
 }
 
-Complex getConjugateScalar(Complex scalar) {
-	
-	Complex conjScalar;
-	conjScalar.real =   scalar.real;
-	conjScalar.imag = - scalar.imag;
-	return conjScalar;
-}
 
-ComplexMatrix2 getConjugateMatrix(ComplexMatrix2 matrix) {
-	
-	ComplexMatrix2 conjMatrix;
-	conjMatrix.r0c0 = getConjugateScalar(matrix.r0c0);
-	conjMatrix.r0c1 = getConjugateScalar(matrix.r0c1);
-	conjMatrix.r1c0 = getConjugateScalar(matrix.r1c0);
-	conjMatrix.r1c1 = getConjugateScalar(matrix.r1c1);
-	return conjMatrix;
-}
-
-void shiftIndices(int* indices, int numIndices, int shift) {
-	for (int j=0; j < numIndices; j++)
-		indices[j] += shift;
-}
 
 
 

--- a/QuEST/QuEST_common.c
+++ b/QuEST/QuEST_common.c
@@ -24,6 +24,7 @@ static const char* errorMessages[] = {
 	[E_INVALID_NUM_QUBITS] = "Invalid number of qubits. Must create >0.",
 	[E_INVALID_TARGET_QUBIT] = "Invalid target qubit. Note qubits are zero indexed.",
 	[E_INVALID_CONTROL_QUBIT] = "Invalid control qubit. Note qubits are zero indexed.",
+	[E_INVALID_STATE_INDEX] = "Invalid state index. Must be >=0 and <2^numQubits.",
 	[E_TARGET_IS_CONTROL] = "Control qubit cannot equal target qubit.",
 	[E_TARGET_IN_CONTROLS] = "Control qubits cannot include target qubit.",
 	[E_INVALID_NUM_CONTROLS] = "Invalid number of control qubits. Must be >0 and <numQubits.",
@@ -164,7 +165,7 @@ REAL statevec_getProbEl(QubitRegister qureg, long long int index){
 }
 
 int statevec_getNumQubits(QubitRegister qureg){
-    return qureg.numQubits;
+    return qureg.numQubitsInStateVec;
 }
 
 int statevec_getNumAmps(QubitRegister qureg){
@@ -190,11 +191,11 @@ void reportState(QubitRegister qureg){
 }
 
 void reportQubitRegisterParams(QubitRegister qureg){
-    long long int numAmps = 1L << qureg.numQubits;
+    long long int numAmps = 1L << qureg.numQubitsInStateVec;
     long long int numAmpsPerRank = numAmps/qureg.numChunks;
     if (qureg.chunkId==0){
         printf("QUBITS:\n");
-        printf("Number of qubits is %d.\n", qureg.numQubits);
+        printf("Number of qubits is %d.\n", qureg.numQubitsInStateVec);
         printf("Number of amps is %lld.\n", numAmps);
         printf("Number of amps per rank is %lld.\n", numAmpsPerRank);
     }

--- a/QuEST/QuEST_common.c
+++ b/QuEST/QuEST_common.c
@@ -19,6 +19,27 @@
 # include <stdio.h>
 # include <stdlib.h>
 
+// error codes in QuEST_internal.h
+static const char* errorMessages[] = {
+	[E_INVALID_NUM_QUBITS] = "Invalid number of qubits. Must create >0.",
+	[E_INVALID_TARGET_QUBIT] = "Invalid target qubit. Note qubits are zero indexed.",
+	[E_INVALID_CONTROL_QUBIT] = "Invalid control qubit. Note qubits are zero indexed.",
+	[E_TARGET_IS_CONTROL] = "Control qubit cannot equal target qubit.",
+	[E_TARGET_IN_CONTROLS] = "Control qubits cannot include target qubit.",
+	[E_INVALID_NUM_CONTROLS] = "Invalid number of control qubits. Must be >0 and <numQubits.",
+	[E_NON_UNITARY_MATRIX] = "Matrix is not unitary.",
+	[E_NON_UNITARY_COMPACT] = "Compact matrix is not unitary.",
+	[E_SYS_TOO_BIG_TO_PRINT] = "Invalid system size. Cannot print output for systems greater than 5 qubits.",
+	[E_COLLAPSE_STATE_ZERO_PROB] = "Can't collapse to state with zero probability.",
+	[E_INVALID_QUBIT_OUTCOME] = "Invalid measurement outcome -- must be either 0 or 1.",
+	[E_CANNOT_OPEN_FILE] = "Could not open file",
+	[E_SECOND_ARG_MUST_BE_STATEVEC] = "Second argument must be a state-vector.",
+	[E_MISMATCHING_REGISTER_DIMENSIONS] = "Dimensions of the qubit registers don't match.",
+	[E_DEFINED_ONLY_FOR_STATEVECS] = "Valid only for state-vectors.",
+	[E_DEFINED_ONLY_FOR_DENSMATRS] = "Valid only for density matrices."
+};
+
+/*
 const char* errorCodes[] = {
     "Success",                                              // 0
     "Invalid target qubit. Note qubits are zero indexed.",  // 1
@@ -26,7 +47,7 @@ const char* errorCodes[] = {
     "Control qubit cannot equal target qubit.",             // 3
     "Invalid number of control qubits",                     // 4
     "Invalid unitary matrix.",                              // 5
-    "Invalid rotation arguments.",                          // 6
+    "as" // wot, this is actually compact non-initary       // 6
     "Invalid system size. Cannot print output for systems greater than 5 qubits.", // 7
     "Can't collapse to state with zero probability.", 		// 8
     "Invalid number of qubits.", 							// 9
@@ -38,21 +59,22 @@ const char* errorCodes[] = {
 	"This operation is only defined for two pure states.",	// 15
 	"An non-unitary internal operation (phaseShift) occured.", //16
 };
+*/
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void exitWithError(int errorCode, const char* func){
+void exitWithError(ErrorCode code, const char* func){
     printf("!!!\n");
-    printf("QuEST Error in function %s: %s\n", func, errorCodes[errorCode]);
+    printf("QuEST Error in function %s: %s\n", func, errorMessages[code]);
     printf("!!!\n");
     printf("exiting..\n");
-    exit(errorCode);
+    exit(code);
 }
 
-void QuESTAssert(int isValid, int errorCode, const char* func){
-    if (!isValid) exitWithError(errorCode, func);
+void QuESTAssert(int isValid, ErrorCode code, const char* func){
+    if (!isValid) exitWithError(code, func);
 }
 
 unsigned long int hashString(char *str){

--- a/QuEST/QuEST_common.c
+++ b/QuEST/QuEST_common.c
@@ -59,6 +59,26 @@ void shiftIndices(int* indices, int numIndices, int shift) {
 		indices[j] += shift;
 }
 
+int generateMeasurementOutcome(REAL zeroProb, REAL *outcomeProb) {
+	
+	// randomly choose outcome
+	int outcome;
+    if (zeroProb < REAL_EPS) 
+		outcome = 1;
+    else if (1-zeroProb < REAL_EPS) 
+		outcome = 0;
+    else
+        outcome = (genrand_real1() > zeroProb);
+	
+	// set probability of outcome
+	if (outcome == 0)
+		*outcomeProb = zeroProb;
+	else
+		*outcomeProb = 1 - zeroProb;
+	
+	return outcome;
+}
+
 unsigned long int hashString(char *str){
     unsigned long int hash = 5381;
     int c;
@@ -255,7 +275,21 @@ void statevec_controlledRotateZ(QubitRegister qureg, const int controlQubit, con
     statevec_controlledRotateAroundAxis(qureg, controlQubit, targetQubit, angle, unitAxis);
 }
 
+int statevec_measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb) {
+	
+	REAL zeroProb = statevec_findProbabilityOfOutcome(qureg, measureQubit, 0);
+	int outcome = generateMeasurementOutcome(zeroProb, outcomeProb);
+	statevec_collapseToKnownProbOutcome(qureg, measureQubit, outcome, *outcomeProb);
+	return outcome;
+}
 
+int densmatr_measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb) {
+	
+	REAL zeroProb = densmatr_findProbabilityOfOutcome(qureg, measureQubit, 0);
+	int outcome = generateMeasurementOutcome(zeroProb, outcomeProb);
+	densmatr_collapseToKnownProbOutcome(qureg, measureQubit, outcome, *outcomeProb);
+	return outcome;
+}
 
 
 

--- a/QuEST/QuEST_common.c
+++ b/QuEST/QuEST_common.c
@@ -7,6 +7,7 @@
 # include "QuEST.h"
 # include "QuEST_internal.h"
 # include "QuEST_precision.h"
+# include "QuEST_validation.h"
 # include "QuEST_ops.h"
 # include "mt19937ar.h"
 
@@ -15,68 +16,15 @@
 # include <sys/types.h> 
 # include <sys/time.h>
 # include <sys/param.h>
-
 # include <stdio.h>
 # include <stdlib.h>
 
-// error codes in QuEST_internal.h
-static const char* errorMessages[] = {
-	[E_INVALID_NUM_QUBITS] = "Invalid number of qubits. Must create >0.",
-	[E_INVALID_TARGET_QUBIT] = "Invalid target qubit. Note qubits are zero indexed.",
-	[E_INVALID_CONTROL_QUBIT] = "Invalid control qubit. Note qubits are zero indexed.",
-	[E_INVALID_STATE_INDEX] = "Invalid state index. Must be >=0 and <2^numQubits.",
-	[E_TARGET_IS_CONTROL] = "Control qubit cannot equal target qubit.",
-	[E_TARGET_IN_CONTROLS] = "Control qubits cannot include target qubit.",
-	[E_INVALID_NUM_CONTROLS] = "Invalid number of control qubits. Must be >0 and <numQubits.",
-	[E_NON_UNITARY_MATRIX] = "Matrix is not unitary.",
-	[E_NON_UNITARY_COMPACT] = "Compact matrix is not unitary.",
-	[E_SYS_TOO_BIG_TO_PRINT] = "Invalid system size. Cannot print output for systems greater than 5 qubits.",
-	[E_COLLAPSE_STATE_ZERO_PROB] = "Can't collapse to state with zero probability.",
-	[E_INVALID_QUBIT_OUTCOME] = "Invalid measurement outcome -- must be either 0 or 1.",
-	[E_CANNOT_OPEN_FILE] = "Could not open file",
-	[E_SECOND_ARG_MUST_BE_STATEVEC] = "Second argument must be a state-vector.",
-	[E_MISMATCHING_REGISTER_DIMENSIONS] = "Dimensions of the qubit registers don't match.",
-	[E_DEFINED_ONLY_FOR_STATEVECS] = "Valid only for state-vectors.",
-	[E_DEFINED_ONLY_FOR_DENSMATRS] = "Valid only for density matrices."
-};
-
-/*
-const char* errorCodes[] = {
-    "Success",                                              // 0
-    "Invalid target qubit. Note qubits are zero indexed.",  // 1
-    "Invalid control qubit. Note qubits are zero indexed.", // 2 
-    "Control qubit cannot equal target qubit.",             // 3
-    "Invalid number of control qubits",                     // 4
-    "Invalid unitary matrix.",                              // 5
-    "as" // wot, this is actually compact non-initary       // 6
-    "Invalid system size. Cannot print output for systems greater than 5 qubits.", // 7
-    "Can't collapse to state with zero probability.", 		// 8
-    "Invalid number of qubits.", 							// 9
-    "Invalid measurement outcome -- must be either 0 or 1.",// 10
-    "Could not open file.",									// 11
-	"Second argument must be a pure state, not a density matrix.", // 12
-	"Dimensions of the qubit registers do not match.", 		// 13
-	"This operation is only defined for density matrices.",	// 14
-	"This operation is only defined for two pure states.",	// 15
-	"An non-unitary internal operation (phaseShift) occured.", //16
-};
-*/
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void exitWithError(ErrorCode code, const char* func){
-    printf("!!!\n");
-    printf("QuEST Error in function %s: %s\n", func, errorMessages[code]);
-    printf("!!!\n");
-    printf("exiting..\n");
-    exit(code);
-}
 
-void QuESTAssert(int isValid, ErrorCode code, const char* func){
-    if (!isValid) exitWithError(code, func);
-}
 
 unsigned long int hashString(char *str){
     unsigned long int hash = 5381;
@@ -124,39 +72,7 @@ int validateUnitComplex(Complex alpha) {
 	return (absReal(1 - sqrt(alpha.real*alpha.real + alpha.imag*alpha.imag)) < REAL_EPS); 
 }
 
-int validateAlphaBeta(Complex alpha, Complex beta){
-    if ( absReal(alpha.real*alpha.real 
-                + alpha.imag*alpha.imag
-                + beta.real*beta.real 
-                + beta.imag*beta.imag - 1) > REAL_EPS ) return 0;
-    else return 1;
-}
 
-int validateUnitVector(REAL ux, REAL uy, REAL uz){
-    if ( absReal(sqrt(ux*ux + uy*uy + uz*uz) - 1) > REAL_EPS ) return 0;
-    else return 1;
-}
-
-int validateMatrixIsUnitary(ComplexMatrix2 u){
-
-    if ( absReal(u.r0c0.real*u.r0c0.real 
-                + u.r0c0.imag*u.r0c0.imag
-                + u.r1c0.real*u.r1c0.real
-                + u.r1c0.imag*u.r1c0.imag - 1) > REAL_EPS ) return 0;
-    if ( absReal(u.r0c1.real*u.r0c1.real 
-                + u.r0c1.imag*u.r0c1.imag
-                + u.r1c1.real*u.r1c1.real
-                + u.r1c1.imag*u.r1c1.imag - 1) > REAL_EPS ) return 0;
-    if ( absReal(u.r0c0.real*u.r0c1.real 
-                + u.r0c0.imag*u.r0c1.imag
-                + u.r1c0.real*u.r1c1.real
-                + u.r1c0.imag*u.r1c1.imag) > REAL_EPS ) return 0;
-    if ( absReal(u.r0c1.real*u.r0c0.imag
-                - u.r0c0.real*u.r0c1.imag
-                + u.r1c1.real*u.r1c0.imag
-                - u.r1c0.real*u.r1c1.imag) > REAL_EPS ) return 0;
-    return 1;
-}
 
 REAL statevec_getProbEl(QubitRegister qureg, long long int index){
     REAL real = statevec_getRealAmpEl(qureg, index);

--- a/QuEST/QuEST_internal.h
+++ b/QuEST/QuEST_internal.h
@@ -15,6 +15,8 @@ extern "C" {
 
 unsigned long int hashString(char *str);
 
+REAL getVectorMagnitude(Vector vec);
+
 Complex getConjugateScalar(Complex scalar);
 
 ComplexMatrix2 getConjugateMatrix(ComplexMatrix2 matr);

--- a/QuEST/QuEST_internal.h
+++ b/QuEST/QuEST_internal.h
@@ -13,11 +13,29 @@
 extern "C" {
 # endif
 
-extern const char* errorCodes[];
+typedef enum {
+	E_SUCCESS=0,
+	E_INVALID_NUM_QUBITS,
+	E_INVALID_TARGET_QUBIT,
+	E_INVALID_CONTROL_QUBIT,
+	E_TARGET_IS_CONTROL,
+	E_TARGET_IN_CONTROLS,
+	E_INVALID_NUM_CONTROLS,
+	E_NON_UNITARY_MATRIX,
+	E_NON_UNITARY_COMPACT,
+	E_SYS_TOO_BIG_TO_PRINT,
+	E_COLLAPSE_STATE_ZERO_PROB,
+	E_INVALID_QUBIT_OUTCOME,
+	E_CANNOT_OPEN_FILE,
+	E_SECOND_ARG_MUST_BE_STATEVEC,
+	E_MISMATCHING_REGISTER_DIMENSIONS,
+	E_DEFINED_ONLY_FOR_STATEVECS,
+	E_DEFINED_ONLY_FOR_DENSMATRS
+} ErrorCode;
 
-void exitWithError(int errorCode, const char *func);
+void exitWithError(ErrorCode code, const char *func);
 
-void QuESTAssert(int isValid, int errorCode, const char *func);
+void QuESTAssert(int isValid, ErrorCode code, const char *func);
 
 unsigned long int hashString(char *str);
 

--- a/QuEST/QuEST_internal.h
+++ b/QuEST/QuEST_internal.h
@@ -13,39 +13,7 @@
 extern "C" {
 # endif
 
-typedef enum {
-	E_SUCCESS=0,
-	E_INVALID_NUM_QUBITS,
-	E_INVALID_TARGET_QUBIT,
-	E_INVALID_CONTROL_QUBIT,
-	E_TARGET_IS_CONTROL,
-	E_TARGET_IN_CONTROLS,
-	E_INVALID_NUM_CONTROLS,
-	E_NON_UNITARY_MATRIX,
-	E_NON_UNITARY_COMPACT,
-	E_SYS_TOO_BIG_TO_PRINT,
-	E_COLLAPSE_STATE_ZERO_PROB,
-	E_INVALID_QUBIT_OUTCOME,
-	E_CANNOT_OPEN_FILE,
-	E_SECOND_ARG_MUST_BE_STATEVEC,
-	E_MISMATCHING_REGISTER_DIMENSIONS,
-	E_DEFINED_ONLY_FOR_STATEVECS,
-	E_DEFINED_ONLY_FOR_DENSMATRS
-} ErrorCode;
-
-void exitWithError(ErrorCode code, const char *func);
-
-void QuESTAssert(int isValid, ErrorCode code, const char *func);
-
 unsigned long int hashString(char *str);
-
-int validateUnitComplex(Complex alpha);
-
-int validateMatrixIsUnitary(ComplexMatrix2 u);
-
-int validateAlphaBeta(Complex alpha, Complex beta);
-
-int validateUnitVector(REAL ux, REAL uy, REAL uz);
 
 Complex getConjugateScalar(Complex scalar);
 

--- a/QuEST/QuEST_ops.h
+++ b/QuEST/QuEST_ops.h
@@ -25,6 +25,11 @@ void densmatr_initPureState(QubitRegister targetQureg, QubitRegister copyQureg);
 REAL densmatr_calcTotalProbability(QubitRegister qureg);
 
 REAL densmatr_findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int outcome);
+
+void densmatr_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL outcomeProb);
+	
+int densmatr_measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb);
+	
 	
 /* operations upon density matrices */
 	
@@ -126,11 +131,11 @@ void statevec_controlledNot(QubitRegister qureg, const int controlQubit, const i
 
 REAL statevec_findProbabilityOfOutcome(QubitRegister qureg, const int measureQubit, int outcome);
 
-REAL statevec_collapseToOutcome(QubitRegister qureg, const int measureQubit, int outcome);
+void statevec_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQubit, int outcome, REAL outcomeProb);
 
-int statevec_measure(QubitRegister qureg, int measureQubit);
+int statevec_measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb);
 
-int statevec_measureWithStats(QubitRegister qureg, int measureQubit, REAL *stateProb);
+
 
 # ifdef __cplusplus
 }

--- a/QuEST/QuEST_ops.h
+++ b/QuEST/QuEST_ops.h
@@ -37,7 +37,7 @@ void statevec_reportStateToScreen(QubitRegister qureg, QuESTEnv env, int reportR
 
 int statevec_compareStates(QubitRegister mq1, QubitRegister mq2, REAL precision);
 
-void statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], QuESTEnv env);
+int statevec_initStateFromSingleFile(QubitRegister *qureg, char filename[200], QuESTEnv env);
 
 void statevec_initStateOfSingleQubit(QubitRegister *qureg, int qubitId, int outcome);
 

--- a/QuEST/QuEST_ops.h
+++ b/QuEST/QuEST_ops.h
@@ -40,10 +40,6 @@ void statevec_createQubitRegister(QubitRegister *qureg, int numQubits, QuESTEnv 
 
 void statevec_destroyQubitRegister(QubitRegister qureg, QuESTEnv env);
 
-int statevec_getNumQubits(QubitRegister qureg);
-
-int statevec_getNumAmps(QubitRegister qureg);
-
 void statevec_initStateZero(QubitRegister qureg);
 
 void statevec_initStatePlus(QubitRegister qureg);

--- a/QuEST/QuEST_ops.h
+++ b/QuEST/QuEST_ops.h
@@ -30,7 +30,6 @@ void densmatr_collapseToKnownProbOutcome(QubitRegister qureg, const int measureQ
 	
 int densmatr_measureWithStats(QubitRegister qureg, int measureQubit, REAL *outcomeProb);
 	
-	
 /* operations upon density matrices */
 	
 void statevec_reportStateToScreen(QubitRegister qureg, QuESTEnv env, int reportRank);

--- a/QuEST/QuEST_ops.h
+++ b/QuEST/QuEST_ops.h
@@ -13,7 +13,7 @@
 # ifdef __cplusplus
 extern "C" {
 # endif
-	
+
 /* operations upon state-vectors */
 
 void densmatr_initStatePlus(QubitRegister targetQureg);

--- a/QuEST/QuEST_validation.c
+++ b/QuEST/QuEST_validation.c
@@ -85,6 +85,14 @@ void auto_validateMeasurementProb(REAL prob, const char* caller) {
 	QuESTAssert(prob>REAL_EPS, E_COLLAPSE_STATE_ZERO_PROB, caller);
 }
 
+void auto_validateMatchingQuregDims(QubitRegister qureg1, QubitRegister qureg2, const char *caller) {
+	QuESTAssert(qureg1.numQubitsRepresented==qureg2.numQubitsRepresented, E_MISMATCHING_REGISTER_DIMENSIONS, caller);
+}
+
+void auto_validateSecondQuregStateVec(QubitRegister qureg2, const char *caller) {
+	QuESTAssert( ! qureg2.isDensityMatrix, E_SECOND_ARG_MUST_BE_STATEVEC, caller);
+}
+
 static const char* errorMessages[] = {
 	[E_INVALID_NUM_QUBITS] = "Invalid number of qubits. Must create >0.",
 	[E_INVALID_TARGET_QUBIT] = "Invalid target qubit. Note qubits are zero indexed.",
@@ -102,8 +110,8 @@ static const char* errorMessages[] = {
 	[E_CANNOT_OPEN_FILE] = "Could not open file",
 	[E_SECOND_ARG_MUST_BE_STATEVEC] = "Second argument must be a state-vector.",
 	[E_MISMATCHING_REGISTER_DIMENSIONS] = "Dimensions of the qubit registers don't match.",
-	[E_DEFINED_ONLY_FOR_STATEVECS] = "Valid only for state-vectors.",
-	[E_DEFINED_ONLY_FOR_DENSMATRS] = "Valid only for density matrices."
+	[E_DEFINED_ONLY_FOR_STATEVECS] = "Operation valid only for state-vectors.",
+	[E_DEFINED_ONLY_FOR_DENSMATRS] = "Operation valid only for density matrices."
 };
 
 /*

--- a/QuEST/QuEST_validation.c
+++ b/QuEST/QuEST_validation.c
@@ -81,6 +81,10 @@ void auto_validateOutcome(int outcome, const char* caller) {
 	QuESTAssert(outcome==0 || outcome==1, E_INVALID_QUBIT_OUTCOME, caller);
 }
 
+void auto_validateMeasurementProb(REAL prob, const char* caller) {
+	QuESTAssert(prob>REAL_EPS, E_COLLAPSE_STATE_ZERO_PROB, caller);
+}
+
 static const char* errorMessages[] = {
 	[E_INVALID_NUM_QUBITS] = "Invalid number of qubits. Must create >0.",
 	[E_INVALID_TARGET_QUBIT] = "Invalid target qubit. Note qubits are zero indexed.",

--- a/QuEST/QuEST_validation.c
+++ b/QuEST/QuEST_validation.c
@@ -15,9 +15,21 @@ extern "C" {
 # include <stdio.h>
 # include <stdlib.h>
 		
-void myTestFunc(const char* caller) {
-	printf("Called from: %s\n", caller);
+
+void auto_validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller) {
+	QuESTAssert(stateInd>=0 && stateInd<qureg.numAmpsTotal, E_INVALID_STATE_INDEX, caller);
 }
+
+void auto_validateTarget(QubitRegister qureg, int targetQubit, const char* caller) {
+	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, caller);
+}
+
+void auto_validateControlTarget(QubitRegister qureg, int controlQubit, int targetQubit, const char* caller) {
+	auto_validateTarget(qureg, targetQubit, caller);
+	QuESTAssert(controlQubit>=0 && controlQubit<qureg.numQubitsRepresented, E_INVALID_CONTROL_QUBIT, caller);
+	QuESTAssert(controlQubit != targetQubit, E_TARGET_IS_CONTROL, caller);
+}
+
 
 static const char* errorMessages[] = {
 	[E_INVALID_NUM_QUBITS] = "Invalid number of qubits. Must create >0.",

--- a/QuEST/QuEST_validation.c
+++ b/QuEST/QuEST_validation.c
@@ -59,30 +59,6 @@ static const char* errorMessages[] = {
 	[E_DEFINED_ONLY_FOR_DENSMATRS] = "Operation valid only for density matrices."
 };
 
-/*
- OLD CODES: MIGHT BE NEEDED IN REFACTORING OLD VALIDATION
-
-const char* errorCodes[] = {
-    "Success",                                              // 0
-    "Invalid target qubit. Note qubits are zero indexed.",  // 1
-    "Invalid control qubit. Note qubits are zero indexed.", // 2 
-    "Control qubit cannot equal target qubit.",             // 3
-    "Invalid number of control qubits",                     // 4
-    "Invalid unitary matrix.",                              // 5
-    "as" // wot, this is actually compact non-initary       // 6
-    "Invalid system size. Cannot print output for systems greater than 5 qubits.", // 7
-    "Can't collapse to state with zero probability.", 		// 8
-    "Invalid number of qubits.", 							// 9
-    "Invalid measurement outcome -- must be either 0 or 1.",// 10
-    "Could not open file.",									// 11
-	"Second argument must be a pure state, not a density matrix.", // 12
-	"Dimensions of the qubit registers do not match.", 		// 13
-	"This operation is only defined for density matrices.",	// 14
-	"This operation is only defined for two pure states.",	// 15
-	"An non-unitary internal operation (phaseShift) occured.", //16
-};
-*/
-
 void exitWithError(ErrorCode code, const char* func){
     printf("!!!\n");
     printf("QuEST Error in function %s: %s\n", func, errorMessages[code]);

--- a/QuEST/QuEST_validation.c
+++ b/QuEST/QuEST_validation.c
@@ -1,0 +1,115 @@
+// Distributed under MIT licence. See https://github.com/aniabrown/QuEST_GPU/blob/master/LICENCE.txt for details
+
+/** @file
+ * Provides validation of user input
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	
+# include "QuEST.h"
+# include "QuEST_precision.h"
+# include "QuEST_validation.h"
+
+# include <stdio.h>
+# include <stdlib.h>
+		
+void myTestFunc(const char* caller) {
+	printf("Called from: %s\n", caller);
+}
+
+static const char* errorMessages[] = {
+	[E_INVALID_NUM_QUBITS] = "Invalid number of qubits. Must create >0.",
+	[E_INVALID_TARGET_QUBIT] = "Invalid target qubit. Note qubits are zero indexed.",
+	[E_INVALID_CONTROL_QUBIT] = "Invalid control qubit. Note qubits are zero indexed.",
+	[E_INVALID_STATE_INDEX] = "Invalid state index. Must be >=0 and <2^numQubits.",
+	[E_TARGET_IS_CONTROL] = "Control qubit cannot equal target qubit.",
+	[E_TARGET_IN_CONTROLS] = "Control qubits cannot include target qubit.",
+	[E_INVALID_NUM_CONTROLS] = "Invalid number of control qubits. Must be >0 and <numQubits.",
+	[E_NON_UNITARY_MATRIX] = "Matrix is not unitary.",
+	[E_NON_UNITARY_COMPACT] = "Compact matrix is not unitary.",
+	[E_SYS_TOO_BIG_TO_PRINT] = "Invalid system size. Cannot print output for systems greater than 5 qubits.",
+	[E_COLLAPSE_STATE_ZERO_PROB] = "Can't collapse to state with zero probability.",
+	[E_INVALID_QUBIT_OUTCOME] = "Invalid measurement outcome -- must be either 0 or 1.",
+	[E_CANNOT_OPEN_FILE] = "Could not open file",
+	[E_SECOND_ARG_MUST_BE_STATEVEC] = "Second argument must be a state-vector.",
+	[E_MISMATCHING_REGISTER_DIMENSIONS] = "Dimensions of the qubit registers don't match.",
+	[E_DEFINED_ONLY_FOR_STATEVECS] = "Valid only for state-vectors.",
+	[E_DEFINED_ONLY_FOR_DENSMATRS] = "Valid only for density matrices."
+};
+
+/*
+ OLD CODES: MIGHT BE NEEDED IN REFACTORING OLD VALIDATION
+
+const char* errorCodes[] = {
+    "Success",                                              // 0
+    "Invalid target qubit. Note qubits are zero indexed.",  // 1
+    "Invalid control qubit. Note qubits are zero indexed.", // 2 
+    "Control qubit cannot equal target qubit.",             // 3
+    "Invalid number of control qubits",                     // 4
+    "Invalid unitary matrix.",                              // 5
+    "as" // wot, this is actually compact non-initary       // 6
+    "Invalid system size. Cannot print output for systems greater than 5 qubits.", // 7
+    "Can't collapse to state with zero probability.", 		// 8
+    "Invalid number of qubits.", 							// 9
+    "Invalid measurement outcome -- must be either 0 or 1.",// 10
+    "Could not open file.",									// 11
+	"Second argument must be a pure state, not a density matrix.", // 12
+	"Dimensions of the qubit registers do not match.", 		// 13
+	"This operation is only defined for density matrices.",	// 14
+	"This operation is only defined for two pure states.",	// 15
+	"An non-unitary internal operation (phaseShift) occured.", //16
+};
+*/
+
+void exitWithError(ErrorCode code, const char* func){
+    printf("!!!\n");
+    printf("QuEST Error in function %s: %s\n", func, errorMessages[code]);
+    printf("!!!\n");
+    printf("exiting..\n");
+    exit(code);
+}
+
+void QuESTAssert(int isValid, ErrorCode code, const char* func){
+    if (!isValid) exitWithError(code, func);
+}
+
+int validateAlphaBeta(Complex alpha, Complex beta){
+    if ( absReal(alpha.real*alpha.real 
+                + alpha.imag*alpha.imag
+                + beta.real*beta.real 
+                + beta.imag*beta.imag - 1) > REAL_EPS ) return 0;
+    else return 1;
+}
+
+int validateUnitVector(REAL ux, REAL uy, REAL uz){
+    if ( absReal(sqrt(ux*ux + uy*uy + uz*uz) - 1) > REAL_EPS ) return 0;
+    else return 1;
+}
+
+int validateMatrixIsUnitary(ComplexMatrix2 u){
+
+    if ( absReal(u.r0c0.real*u.r0c0.real 
+                + u.r0c0.imag*u.r0c0.imag
+                + u.r1c0.real*u.r1c0.real
+                + u.r1c0.imag*u.r1c0.imag - 1) > REAL_EPS ) return 0;
+    if ( absReal(u.r0c1.real*u.r0c1.real 
+                + u.r0c1.imag*u.r0c1.imag
+                + u.r1c1.real*u.r1c1.real
+                + u.r1c1.imag*u.r1c1.imag - 1) > REAL_EPS ) return 0;
+    if ( absReal(u.r0c0.real*u.r0c1.real 
+                + u.r0c0.imag*u.r0c1.imag
+                + u.r1c0.real*u.r1c1.real
+                + u.r1c0.imag*u.r1c1.imag) > REAL_EPS ) return 0;
+    if ( absReal(u.r0c1.real*u.r0c0.imag
+                - u.r0c0.real*u.r0c1.imag
+                + u.r1c1.real*u.r1c0.imag
+                - u.r1c0.real*u.r1c1.imag) > REAL_EPS ) return 0;
+    return 1;
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/QuEST/QuEST_validation.c
+++ b/QuEST/QuEST_validation.c
@@ -87,39 +87,46 @@ void QuESTAssert(int isValid, ErrorCode code, const char* func){
     if (!isValid) exitWithError(code, func);
 }
 
-int validateAlphaBeta(Complex alpha, Complex beta){
-    if ( absReal(alpha.real*alpha.real 
+//int validateUnitComplex(Complex alpha) {
+int isComplexUnit(Complex alpha) {
+	return (absReal(1 - sqrt(alpha.real*alpha.real + alpha.imag*alpha.imag)) < REAL_EPS); 
+}
+
+//int validateUnitVector(REAL ux, REAL uy, REAL uz){
+int isVectorUnit(REAL ux, REAL uy, REAL uz) {
+    return (absReal(1 - sqrt(ux*ux + uy*uy + uz*uz)) < REAL_EPS );
+}
+
+//int validateAlphaBeta(Complex alpha, Complex beta){
+int isComplexPairUnitary(Complex alpha, Complex beta) {
+    return ( absReal( -1
+				+ alpha.real*alpha.real 
                 + alpha.imag*alpha.imag
                 + beta.real*beta.real 
-                + beta.imag*beta.imag - 1) > REAL_EPS ) return 0;
-    else return 1;
+                + beta.imag*beta.imag) < REAL_EPS );
 }
 
-int validateUnitVector(REAL ux, REAL uy, REAL uz){
-    if ( absReal(sqrt(ux*ux + uy*uy + uz*uz) - 1) > REAL_EPS ) return 0;
-    else return 1;
-}
-
-int validateMatrixIsUnitary(ComplexMatrix2 u){
-
-    if ( absReal(u.r0c0.real*u.r0c0.real 
+// int validateMatrixIsUnitary(ComplexMatrix2 u){
+int isMatrixUnitary(ComplexMatrix2 u) {
+    if ( absReal( u.r0c0.real*u.r0c0.real 
                 + u.r0c0.imag*u.r0c0.imag
                 + u.r1c0.real*u.r1c0.real
                 + u.r1c0.imag*u.r1c0.imag - 1) > REAL_EPS ) return 0;
-    if ( absReal(u.r0c1.real*u.r0c1.real 
+    if ( absReal( u.r0c1.real*u.r0c1.real 
                 + u.r0c1.imag*u.r0c1.imag
                 + u.r1c1.real*u.r1c1.real
                 + u.r1c1.imag*u.r1c1.imag - 1) > REAL_EPS ) return 0;
-    if ( absReal(u.r0c0.real*u.r0c1.real 
+    if ( absReal( u.r0c0.real*u.r0c1.real 
                 + u.r0c0.imag*u.r0c1.imag
                 + u.r1c0.real*u.r1c1.real
                 + u.r1c0.imag*u.r1c1.imag) > REAL_EPS ) return 0;
-    if ( absReal(u.r0c1.real*u.r0c0.imag
+    if ( absReal( u.r0c1.real*u.r0c0.imag
                 - u.r0c0.real*u.r0c1.imag
                 + u.r1c1.real*u.r1c0.imag
                 - u.r1c0.real*u.r1c1.imag) > REAL_EPS ) return 0;
     return 1;
 }
+
 
 
 #ifdef __cplusplus

--- a/QuEST/QuEST_validation.c
+++ b/QuEST/QuEST_validation.c
@@ -131,80 +131,80 @@ int isMatrixUnitary(ComplexMatrix2 u) {
     return 1;
 }
 
-void auto_validateCreateNumQubits(int numQubits, const char* caller) {
+void validateCreateNumQubits(int numQubits, const char* caller) {
 	QuESTAssert(numQubits>0, E_INVALID_NUM_QUBITS, caller);
 }
 
-void auto_validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller) {
+void validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller) {
 	QuESTAssert(stateInd>=0 && stateInd<qureg.numAmpsTotal, E_INVALID_STATE_INDEX, caller);
 }
 
-void auto_validateTarget(QubitRegister qureg, int targetQubit, const char* caller) {
+void validateTarget(QubitRegister qureg, int targetQubit, const char* caller) {
 	QuESTAssert(targetQubit>=0 && targetQubit<qureg.numQubitsRepresented, E_INVALID_TARGET_QUBIT, caller);
 }
 
-void auto_validateControl(QubitRegister qureg, int controlQubit, const char* caller) {
+void validateControl(QubitRegister qureg, int controlQubit, const char* caller) {
 	QuESTAssert(controlQubit>=0 && controlQubit<qureg.numQubitsRepresented, E_INVALID_CONTROL_QUBIT, caller);
 }
 
-void auto_validateControlTarget(QubitRegister qureg, int controlQubit, int targetQubit, const char* caller) {
-	auto_validateTarget(qureg, targetQubit, caller);
-	auto_validateControl(qureg, controlQubit, caller);
+void validateControlTarget(QubitRegister qureg, int controlQubit, int targetQubit, const char* caller) {
+	validateTarget(qureg, targetQubit, caller);
+	validateControl(qureg, controlQubit, caller);
 	QuESTAssert(controlQubit != targetQubit, E_TARGET_IS_CONTROL, caller);
 }
 
-void auto_validateNumControls(QubitRegister qureg, const int numControlQubits, const char* caller) {
+void validateNumControls(QubitRegister qureg, const int numControlQubits, const char* caller) {
 	// this could reject repeated qubits and cite "too many"
 	QuESTAssert(numControlQubits>0 && numControlQubits<=qureg.numQubitsRepresented, E_INVALID_NUM_CONTROLS, caller);
 }
 
-void auto_validateMultiControls(QubitRegister qureg, int* controlQubits, const int numControlQubits, const char* caller) {
-	auto_validateNumControls(qureg, numControlQubits, caller);
+void validateMultiControls(QubitRegister qureg, int* controlQubits, const int numControlQubits, const char* caller) {
+	validateNumControls(qureg, numControlQubits, caller);
 	for (int i=0; i < numControlQubits; i++) {
-		auto_validateControl(qureg, controlQubits[i], caller);
+		validateControl(qureg, controlQubits[i], caller);
 	}
 }
 
-void auto_validateMultiControlsTarget(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, const char* caller) {
-	auto_validateTarget(qureg, targetQubit, caller);
-	auto_validateMultiControls(qureg, controlQubits, numControlQubits, caller);
+void validateMultiControlsTarget(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, const char* caller) {
+	validateTarget(qureg, targetQubit, caller);
+	validateMultiControls(qureg, controlQubits, numControlQubits, caller);
 	for (int i=0; i < numControlQubits; i++)
 		QuESTAssert(controlQubits[i] != targetQubit, E_TARGET_IN_CONTROLS, caller);
 }
 
-void auto_validateUnitaryMatrix(ComplexMatrix2 u, const char* caller) {
+void validateUnitaryMatrix(ComplexMatrix2 u, const char* caller) {
 	QuESTAssert(isMatrixUnitary(u), E_NON_UNITARY_MATRIX, caller);
 }
 
-void auto_validateUnitaryComplexPair(Complex alpha, Complex beta, const char* caller) {
+void validateUnitaryComplexPair(Complex alpha, Complex beta, const char* caller) {
 	QuESTAssert(isComplexPairUnitary(alpha, beta), E_NON_UNITARY_COMPLEX_PAIR, caller);
 }
 
-void auto_validateVector(Vector vec, const char* caller) {
+void validateVector(Vector vec, const char* caller) {
 	QuESTAssert(getVectorMagnitude(vec) > REAL_EPS, E_ZERO_VECTOR, caller);
 }
 
-void auto_validateStateVecQureg(QubitRegister qureg, const char* caller) {
+void validateStateVecQureg(QubitRegister qureg, const char* caller) {
 	QuESTAssert( ! qureg.isDensityMatrix, E_DEFINED_ONLY_FOR_STATEVECS, caller);
 }
 
-void auto_validatDensityMatrQureg(QubitRegister qureg, const char* caller) {
+void validatDensityMatrQureg(QubitRegister qureg, const char* caller) {
 	QuESTAssert(qureg.isDensityMatrix, E_DEFINED_ONLY_FOR_DENSMATRS, caller);
 }
 
-void auto_validateOutcome(int outcome, const char* caller) {
+void validateOutcome(int outcome, const char* caller) {
 	QuESTAssert(outcome==0 || outcome==1, E_INVALID_QUBIT_OUTCOME, caller);
 }
 
-void auto_validateMeasurementProb(REAL prob, const char* caller) {
+void validateMeasurementProb(REAL prob, const char* caller) {
 	QuESTAssert(prob>REAL_EPS, E_COLLAPSE_STATE_ZERO_PROB, caller);
 }
 
-void auto_validateMatchingQuregDims(QubitRegister qureg1, QubitRegister qureg2, const char *caller) {
+void validateMatchingQuregDims(QubitRegister qureg1, QubitRegister qureg2, const char *caller) {
 	QuESTAssert(qureg1.numQubitsRepresented==qureg2.numQubitsRepresented, E_MISMATCHING_REGISTER_DIMENSIONS, caller);
 }
 
-void auto_validateSecondQuregStateVec(QubitRegister qureg2, const char *caller) {
+void validateSecondQuregStateVec(QubitRegister qureg2, const char *caller) {
 	QuESTAssert( ! qureg2.isDensityMatrix, E_SECOND_ARG_MUST_BE_STATEVEC, caller);
 }
 

--- a/QuEST/QuEST_validation.c
+++ b/QuEST/QuEST_validation.c
@@ -208,6 +208,9 @@ void validateSecondQuregStateVec(QubitRegister qureg2, const char *caller) {
 	QuESTAssert( ! qureg2.isDensityMatrix, E_SECOND_ARG_MUST_BE_STATEVEC, caller);
 }
 
+void validateFileOpened(int found, const char* caller) {
+	QuESTAssert(found, E_CANNOT_OPEN_FILE, caller);
+}
 
 
 #ifdef __cplusplus

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -12,42 +12,36 @@
 # ifdef __cplusplus
 extern "C" {
 # endif
-	
-/* Wraps validation to automatically pass along the caller's signature.
- * N = number, Q = qureg, S = state, T = target, C = control, CS = controls, U = unitary
- * A = alpha, B = beta, V = vector, M = measurement outcome, P = probability
- */
-# define validateCreateNumQubits(N) auto_validateCreateNumQubits(N, __func__)
-# define validateStateIndex(Q, S) auto_validateStateIndex(Q, S, __func__)
-# define validateTarget(Q, T) auto_validateTarget(Q, T, __func__)
-# define validateControlTarget(Q, C, T) auto_validateControlTarget(Q, C, T, __func__)
-# define validateMultiControls(Q, CS, N) auto_validateMultiControls(Q, CS, N, __func__)
-# define validateMultiControlsTarget(Q, CS, N, T) auto_validateMultiControlsTarget(Q, CS, N, T, __func__)
-# define validateUnitaryMatrix(U) auto_validateUnitaryMatrix(U, __func__)
-# define validateUnitaryComplexPair(A, B) auto_validateUnitaryComplexPair(A, B, __func__)
-# define validateVector(V) auto_validateVector(V, __func__)
-# define validateStateVecQureg(Q) auto_validateStateVecQureg(Q, __func__)
-# define validateDensityMatrQureg(Q) auto_validatDensityMatrQureg(Q, __func__)
-# define validateOutcome(M) auto_validateOutcome(M, __func__)
-# define validateMeasurementProb(P) auto_validateMeasurementProb(P, __func__)
-# define validateMatchingQuregDims(Q1, Q2) auto_validateMatchingQuregDims(Q1, Q2, __func__)
-# define validateSecondQuregStateVec(Q2) auto_validateSecondQuregStateVec(Q2, __func__)
 
-void auto_validateCreateNumQubits(int numQubits, const char* caller);
-void auto_validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller);
-void auto_validateTarget(QubitRegister qureg, int targetQubit, const char* caller);
-void auto_validateControlTarget(QubitRegister qureg, int controlQubit, int targetQubit, const char* caller);
-void auto_validateMultiControls(QubitRegister qureg, int* controlQubits, const int numControlQubits, const char* caller);
-void auto_validateMultiControlsTarget(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, const char* caller);
-void auto_validateUnitaryMatrix(ComplexMatrix2 u, const char* caller);
-void auto_validateUnitaryComplexPair(Complex alpha, Complex beta, const char* caller);
-void auto_validateVector(Vector vector, const char* caller);
-void auto_validateStateVecQureg(QubitRegister qureg, const char* caller);
-void auto_validatDensityMatrQureg(QubitRegister qureg, const char* caller);
-void auto_validateOutcome(int outcome, const char* caller);
-void auto_validateMeasurementProb(REAL prob, const char* caller);
-void auto_validateMatchingQuregDims(QubitRegister qureg1, QubitRegister qureg2, const char *caller);
-void auto_validateSecondQuregStateVec(QubitRegister qureg2, const char *caller);
+void validateCreateNumQubits(int numQubits, const char* caller);
+
+void validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller);
+
+void validateTarget(QubitRegister qureg, int targetQubit, const char* caller);
+
+void validateControlTarget(QubitRegister qureg, int controlQubit, int targetQubit, const char* caller);
+
+void validateMultiControls(QubitRegister qureg, int* controlQubits, const int numControlQubits, const char* caller);
+
+void validateMultiControlsTarget(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, const char* caller);
+
+void validateUnitaryMatrix(ComplexMatrix2 u, const char* caller);
+
+void validateUnitaryComplexPair(Complex alpha, Complex beta, const char* caller);
+
+void validateVector(Vector vector, const char* caller);
+
+void validateStateVecQureg(QubitRegister qureg, const char* caller);
+
+void validatDensityMatrQureg(QubitRegister qureg, const char* caller);
+
+void validateOutcome(int outcome, const char* caller);
+
+void validateMeasurementProb(REAL prob, const char* caller);
+
+void validateMatchingQuregDims(QubitRegister qureg1, QubitRegister qureg2, const char *caller);
+
+void validateSecondQuregStateVec(QubitRegister qureg2, const char *caller);
 
 # ifdef __cplusplus
 }

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -49,41 +49,6 @@ void auto_validateMeasurementProb(REAL prob, const char* caller);
 void auto_validateMatchingQuregDims(QubitRegister qureg1, QubitRegister qureg2, const char *caller);
 void auto_validateSecondQuregStateVec(QubitRegister qureg2, const char *caller);
 
-/* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
-typedef enum {
-	E_SUCCESS=0,
-	E_INVALID_NUM_QUBITS,
-	E_INVALID_TARGET_QUBIT,
-	E_INVALID_CONTROL_QUBIT,
-	E_INVALID_STATE_INDEX,
-	E_TARGET_IS_CONTROL,
-	E_TARGET_IN_CONTROLS,
-	E_INVALID_NUM_CONTROLS,
-	E_NON_UNITARY_MATRIX,
-	E_NON_UNITARY_COMPLEX_PAIR,
-	E_ZERO_VECTOR,
-	E_SYS_TOO_BIG_TO_PRINT,
-	E_COLLAPSE_STATE_ZERO_PROB,
-	E_INVALID_QUBIT_OUTCOME,
-	E_CANNOT_OPEN_FILE,
-	E_SECOND_ARG_MUST_BE_STATEVEC,
-	E_MISMATCHING_REGISTER_DIMENSIONS,
-	E_DEFINED_ONLY_FOR_STATEVECS,
-	E_DEFINED_ONLY_FOR_DENSMATRS,
-} ErrorCode;
-
-/* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
-
-void exitWithError(ErrorCode code, const char *func);
-void QuESTAssert(int isValid, ErrorCode code, const char *func);
-
-/* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
-int isComplexUnit(Complex alpha);
-int isMatrixUnitary(ComplexMatrix2 u);
-int isComplexPairUnitary(Complex alpha, Complex beta);
-int isVectorUnit(REAL ux, REAL uy, REAL uz);
-
-
 # ifdef __cplusplus
 }
 # endif

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -13,10 +13,18 @@
 extern "C" {
 # endif
 	
+/* Wraps validation to automatically pass along the caller's signature.
+ * Q = qureg, S = state, T = target, C = control
+ */
+# define validateStateIndex(Q, S) auto_validateStateIndex(Q, S, __func__)
+# define validateTarget(Q, T) auto_validateTarget(Q, T, __func__)
+# define validateControlTarget(Q, C, T) auto_validateControlTarget(Q, C, T, __func__)
 
+void auto_validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller);
+void auto_validateTarget(QubitRegister qureg, int targetQubit, const char* caller);
+void auto_validateControlTarget(QubitRegister qureg, int controlQubit, int targetQubit, const char* caller);
 
-# define testGetCaller() myTestFunc(__func__)
-
+/* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
 typedef enum {
 	E_SUCCESS=0,
 	E_INVALID_NUM_QUBITS,

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -1,0 +1,59 @@
+// Distributed under MIT licence. See https://github.com/aniabrown/QuEST_GPU/blob/master/LICENCE.txt for details
+
+/** @file
+ * Provides defined in QuEST_validation.c which are used by QuEST.c
+ */
+ 
+# ifndef QuEST_VALIDATION
+# define QuEST_VALIDATION
+
+# include "QuEST.h"
+
+# ifdef __cplusplus
+extern "C" {
+# endif
+	
+
+
+# define testGetCaller() myTestFunc(__func__)
+
+typedef enum {
+	E_SUCCESS=0,
+	E_INVALID_NUM_QUBITS,
+	E_INVALID_TARGET_QUBIT,
+	E_INVALID_CONTROL_QUBIT,
+	E_INVALID_STATE_INDEX,
+	E_TARGET_IS_CONTROL,
+	E_TARGET_IN_CONTROLS,
+	E_INVALID_NUM_CONTROLS,
+	E_NON_UNITARY_MATRIX,
+	E_NON_UNITARY_COMPACT,
+	E_SYS_TOO_BIG_TO_PRINT,
+	E_COLLAPSE_STATE_ZERO_PROB,
+	E_INVALID_QUBIT_OUTCOME,
+	E_CANNOT_OPEN_FILE,
+	E_SECOND_ARG_MUST_BE_STATEVEC,
+	E_MISMATCHING_REGISTER_DIMENSIONS,
+	E_DEFINED_ONLY_FOR_STATEVECS,
+	E_DEFINED_ONLY_FOR_DENSMATRS,
+} ErrorCode;
+
+void exitWithError(ErrorCode code, const char *func);
+
+void QuESTAssert(int isValid, ErrorCode code, const char *func);
+
+// need renaming
+int validateUnitComplex(Complex alpha);
+
+int validateMatrixIsUnitary(ComplexMatrix2 u);
+
+int validateAlphaBeta(Complex alpha, Complex beta);
+
+int validateUnitVector(REAL ux, REAL uy, REAL uz);
+
+
+# ifdef __cplusplus
+}
+# endif
+
+# endif // QuEST_VALIDATION

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -30,6 +30,8 @@ extern "C" {
 # define validateDensityMatrQureg(Q) auto_validatDensityMatrQureg(Q, __func__)
 # define validateOutcome(M) auto_validateOutcome(M, __func__)
 # define validateMeasurementProb(P) auto_validateMeasurementProb(P, __func__)
+# define validateMatchingQuregDims(Q1, Q2) auto_validateMatchingQuregDims(Q1, Q2, __func__)
+# define validateSecondQuregStateVec(Q2) auto_validateSecondQuregStateVec(Q2, __func__)
 
 void auto_validateCreateNumQubits(int numQubits, const char* caller);
 void auto_validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller);
@@ -44,6 +46,8 @@ void auto_validateStateVecQureg(QubitRegister qureg, const char* caller);
 void auto_validatDensityMatrQureg(QubitRegister qureg, const char* caller);
 void auto_validateOutcome(int outcome, const char* caller);
 void auto_validateMeasurementProb(REAL prob, const char* caller);
+void auto_validateMatchingQuregDims(QubitRegister qureg1, QubitRegister qureg2, const char *caller);
+void auto_validateSecondQuregStateVec(QubitRegister qureg2, const char *caller);
 
 /* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
 typedef enum {

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -15,7 +15,7 @@ extern "C" {
 	
 /* Wraps validation to automatically pass along the caller's signature.
  * N = number, Q = qureg, S = state, T = target, C = control, CS = controls, U = unitary
- * A = alpha, B = beta, V = vector, M = measurement outcome
+ * A = alpha, B = beta, V = vector, M = measurement outcome, P = probability
  */
 # define validateCreateNumQubits(N) auto_validateCreateNumQubits(N, __func__)
 # define validateStateIndex(Q, S) auto_validateStateIndex(Q, S, __func__)
@@ -27,8 +27,9 @@ extern "C" {
 # define validateUnitaryComplexPair(A, B) auto_validateUnitaryComplexPair(A, B, __func__)
 # define validateVector(V) auto_validateVector(V, __func__)
 # define validateStateVecQureg(Q) auto_validateStateVecQureg(Q, __func__)
-# define validatDensityMatrQureg(Q) auto_validatDensityMatrQureg(Q, __func__)
+# define validateDensityMatrQureg(Q) auto_validatDensityMatrQureg(Q, __func__)
 # define validateOutcome(M) auto_validateOutcome(M, __func__)
+# define validateMeasurementProb(P) auto_validateMeasurementProb(P, __func__)
 
 void auto_validateCreateNumQubits(int numQubits, const char* caller);
 void auto_validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller);
@@ -42,6 +43,7 @@ void auto_validateVector(Vector vector, const char* caller);
 void auto_validateStateVecQureg(QubitRegister qureg, const char* caller);
 void auto_validatDensityMatrQureg(QubitRegister qureg, const char* caller);
 void auto_validateOutcome(int outcome, const char* caller);
+void auto_validateMeasurementProb(REAL prob, const char* caller);
 
 /* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
 typedef enum {

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -14,15 +14,34 @@ extern "C" {
 # endif
 	
 /* Wraps validation to automatically pass along the caller's signature.
- * Q = qureg, S = state, T = target, C = control
+ * N = number, Q = qureg, S = state, T = target, C = control, CS = controls, U = unitary
+ * A = alpha, B = beta, V = vector, M = measurement outcome
  */
+# define validateCreateNumQubits(N) auto_validateCreateNumQubits(N, __func__)
 # define validateStateIndex(Q, S) auto_validateStateIndex(Q, S, __func__)
 # define validateTarget(Q, T) auto_validateTarget(Q, T, __func__)
 # define validateControlTarget(Q, C, T) auto_validateControlTarget(Q, C, T, __func__)
+# define validateMultiControls(Q, CS, N) auto_validateMultiControls(Q, CS, N, __func__)
+# define validateMultiControlsTarget(Q, CS, N, T) auto_validateMultiControlsTarget(Q, CS, N, T, __func__)
+# define validateUnitaryMatrix(U) auto_validateUnitaryMatrix(U, __func__)
+# define validateUnitaryComplexPair(A, B) auto_validateUnitaryComplexPair(A, B, __func__)
+# define validateVector(V) auto_validateVector(V, __func__)
+# define validateStateVecQureg(Q) auto_validateStateVecQureg(Q, __func__)
+# define validatDensityMatrQureg(Q) auto_validatDensityMatrQureg(Q, __func__)
+# define validateOutcome(M) auto_validateOutcome(M, __func__)
 
+void auto_validateCreateNumQubits(int numQubits, const char* caller);
 void auto_validateStateIndex(QubitRegister qureg, long long int stateInd, const char* caller);
 void auto_validateTarget(QubitRegister qureg, int targetQubit, const char* caller);
 void auto_validateControlTarget(QubitRegister qureg, int controlQubit, int targetQubit, const char* caller);
+void auto_validateMultiControls(QubitRegister qureg, int* controlQubits, const int numControlQubits, const char* caller);
+void auto_validateMultiControlsTarget(QubitRegister qureg, int* controlQubits, const int numControlQubits, const int targetQubit, const char* caller);
+void auto_validateUnitaryMatrix(ComplexMatrix2 u, const char* caller);
+void auto_validateUnitaryComplexPair(Complex alpha, Complex beta, const char* caller);
+void auto_validateVector(Vector vector, const char* caller);
+void auto_validateStateVecQureg(QubitRegister qureg, const char* caller);
+void auto_validatDensityMatrQureg(QubitRegister qureg, const char* caller);
+void auto_validateOutcome(int outcome, const char* caller);
 
 /* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
 typedef enum {
@@ -35,7 +54,8 @@ typedef enum {
 	E_TARGET_IN_CONTROLS,
 	E_INVALID_NUM_CONTROLS,
 	E_NON_UNITARY_MATRIX,
-	E_NON_UNITARY_COMPACT,
+	E_NON_UNITARY_COMPLEX_PAIR,
+	E_ZERO_VECTOR,
 	E_SYS_TOO_BIG_TO_PRINT,
 	E_COLLAPSE_STATE_ZERO_PROB,
 	E_INVALID_QUBIT_OUTCOME,
@@ -46,17 +66,15 @@ typedef enum {
 	E_DEFINED_ONLY_FOR_DENSMATRS,
 } ErrorCode;
 
-void exitWithError(ErrorCode code, const char *func);
+/* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
 
+void exitWithError(ErrorCode code, const char *func);
 void QuESTAssert(int isValid, ErrorCode code, const char *func);
 
-// need renaming
+/* BELOW WON'T NEED TO BE EXPOSED AFTER ALL INTEGRATED INTO QuEST_validation.h! :D */
 int isComplexUnit(Complex alpha);
-
 int isMatrixUnitary(ComplexMatrix2 u);
-
 int isComplexPairUnitary(Complex alpha, Complex beta);
-
 int isVectorUnit(REAL ux, REAL uy, REAL uz);
 
 

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -43,6 +43,8 @@ void validateMatchingQuregDims(QubitRegister qureg1, QubitRegister qureg2, const
 
 void validateSecondQuregStateVec(QubitRegister qureg2, const char *caller);
 
+void validateFileOpened(int opened, const char* caller);
+
 # ifdef __cplusplus
 }
 # endif

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -1,7 +1,7 @@
 // Distributed under MIT licence. See https://github.com/aniabrown/QuEST_GPU/blob/master/LICENCE.txt for details
 
 /** @file
- * Provides defined in QuEST_validation.c which are used by QuEST.c
+ * Provides validation defined in QuEST_validation.c which is used exclusively by QuEST.c
  */
  
 # ifndef QuEST_VALIDATION

--- a/QuEST/QuEST_validation.h
+++ b/QuEST/QuEST_validation.h
@@ -51,13 +51,13 @@ void exitWithError(ErrorCode code, const char *func);
 void QuESTAssert(int isValid, ErrorCode code, const char *func);
 
 // need renaming
-int validateUnitComplex(Complex alpha);
+int isComplexUnit(Complex alpha);
 
-int validateMatrixIsUnitary(ComplexMatrix2 u);
+int isMatrixUnitary(ComplexMatrix2 u);
 
-int validateAlphaBeta(Complex alpha, Complex beta);
+int isComplexPairUnitary(Complex alpha, Complex beta);
 
-int validateUnitVector(REAL ux, REAL uy, REAL uz);
+int isVectorUnit(REAL ux, REAL uy, REAL uz);
 
 
 # ifdef __cplusplus

--- a/makefile
+++ b/makefile
@@ -224,7 +224,7 @@ MPI_WRAPPED_COMP = I_MPI_CC=$(COMPILER) OMPI_CC=$(COMPILER) MPICH_CC=$(COMPILER)
 # --- targets
 #
 
-OBJ = QuEST_common.o QuEST.o mt19937ar.o
+OBJ = QuEST.o QuEST_validation.o QuEST_common.o mt19937ar.o
 ifeq ($(GPUACCELERATED), 1)
     OBJ += QuEST_gpu.o
 else ifeq ($(DISTRIBUTED), 1)

--- a/tests/runTests.sh
+++ b/tests/runTests.sh
@@ -19,6 +19,7 @@ else
 	printf "\nCOMPILATION FAILED"
 	printf "\n---------------------\n\n"
 	make clean EXE=runTests --silent
+	rm makefile        
 	exit 1
 fi
 


### PR DESCRIPTION
Previously, the hardware-specific backend code was littered with `QuESTAssert`s which didn't do more than validate user input. Error messages were id'd by their index in a list of strings. This meant...
- enormous code duplication, both between backend files, and functions which perform similar validation
- invalid input would be reported to have occured in an internel function the user didn't directly call
- anonymous numbers all over the place (passed error message ids)
- compiler can't detect invalid error message id
- developer can't recognise incorrect error message id

To fix all of these, user input validation is now centralised into QuEST_validation, which is invoked exclusively by QuEST (which resolves the API). Error messages are id'd by enums with meaningful names (e.g. `E_NON_UNITARY_MATRIX`). Now, input validation
- is maintainable
- is concise
- occurs ASAP
- reports meaningful error locations to user